### PR TITLE
docs: expand README with product overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,84 @@
 
 Aleya is a journaling and mentorship platform that pairs reflective journaling tools with mentor guidance. The repository hosts an Express + PostgreSQL API (`backend/`) and a React client (`frontend/`).
 
+## Product overview
+
+### Vision & purpose
+
+- **One-liner:** Aleya is a journaling and mentorship app that helps people reflect on their emotions, build habits, and grow with guidance.
+- **Who is it for?** Individuals who want to journal for self-growth, mentors who want to support them, and administrators who manage the platform.
+- **Why now?** Mental health challenges continue to rise because advice is often fragmented—focused solely on body, mind, work, or spirit. Aleya takes a holistic approach inspired by a tree: roots (self-care), trunk (purpose), branches (learning and relationships), and fruit (creative expression). Life feels whole only when every part is nurtured, so the product aims to guide users through integrated wellbeing.
+
+### Users & roles
+
+- **Journaler**
+  - Goals: Build a journaling habit, track emotions and mood, and see progress over time.
+  - Pain points: Consistency is difficult and accountability is limited without support.
+- **Mentor**
+  - Goals: Support mentees, spot red flags quickly, and encourage consistent reflection.
+  - Needs: Simple dashboards, digestible entry summaries, and optional notifications.
+- **Administrator**
+  - Goals: Oversee the platform and keep user journeys running smoothly.
+  - Responsibilities: Configure user journeys, manage journal forms, handle user data securely, monitor platform health, and onboard mentors.
+
+### Core features (MVP)
+
+- **Journal entry forms:** A collection of customizable forms rather than a single template. The default form captures mood (happy, loved, proud, relaxed, tired, anxious, angry, sad), the causes of today's emotions, and learnings. Optional fields include sleep, energy, and activities. Mentors can assign additional or specialised forms after both parties confirm the mentorship link.
+- **Authentication:** Email + password or a magic-link flow.
+- **Mentor linking:** Journalers can invite or select mentors, forming a mentorship connection only after mutual consent.
+- **Reminders:** Daily or weekly reminders delivered via email.
+- **Mentor notifications:** Email summaries of mentee entries with privacy controls to respect journaler choices.
+- **Dashboards:** Role-specific dashboards showing streaks, average mood, trendlines, progress overviews, mentee highlights, and low-mood alerts.
+
+### User flows
+
+#### Journaler flow
+
+1. **Sign up & onboarding** – Create an account, complete the profile, and begin journaling immediately with the default form.
+2. **Explore & journal** – Fill in entries using the default form at any time.
+3. **Optionally choose a mentor** – Search for or invite a mentor and send a request.
+4. **Mentor acceptance** – Mentor accepts the request; the journaler confirms, completing the mutual-consent handshake.
+5. **Form assignment** – Mentors can assign additional or custom forms once the link is confirmed.
+6. **Complete forms & submit entries** – Journalers complete default and assigned forms and submit entries.
+7. **Mentor notification flow** – Mentors are notified based on the journaler’s sharing preferences.
+8. **Dashboard review** – Journalers view streaks, mood trends, and progress overviews.
+9. **Account & settings management** – Journalers manage profiles, reset passwords, and may delete the account.
+
+#### Mentor flow
+
+1. **Sign up & onboarding** – Create a profile including expertise, availability, and preferences.
+2. **Login & dashboard access** – View mentee lists, progress summaries, and alerts.
+3. **Accept/decline requests** – Review incoming requests and accept to establish the mutual link.
+4. **Assign forms** – After mutual consent, select or customise forms for each journaler.
+5. **Track progress** – Monitor streaks, mood trends, and flagged entries.
+6. **Engagement & feedback** – Provide encouragement, notes, or comments to mentees.
+7. **Profile & reputation** – Maintain mentor profiles, respond to ratings, and manage account settings.
+
+#### Administrator flow
+
+1. **Sign up & onboarding** – Create an administrator account with elevated access.
+2. **Login & dashboard access** – Manage system-level settings and monitor platform performance.
+3. **Create & manage forms** – Build journal forms mentors can assign to journalers.
+4. **Support mentors** – Onboard new mentors, review profiles, and provide resources.
+5. **Moderation & escalation** – Handle disputes, flag or suspend abusive mentors, and resolve complaints.
+6. **Platform oversight** – Ensure data security, manage user data, and monitor platform health.
+
+### Privacy & controls
+
+- **Data collection:** Journal entries, profile information, mentor–mentee links, and activity streaks.
+- **User choices:** Journalers decide what mentors see—mood only, summaries, or full entries.
+- **Confidentiality:** Default-form data stays private unless explicitly shared by the journaler.
+- **Admin oversight:** Administrators manage forms and journeys but cannot view private journal content.
+- **Security:** Data is stored securely using encryption and access control, with crisis keyword detection available for emergency escalation without exposing private details.
+- **Lifecycle management:** Journalers and mentors can deactivate or delete accounts; data is archived or erased accordingly.
+- **Notifications:** Supports email, push, or in-app notifications, following user preferences.
+
+### Design principles
+
+- **Holistic layout:** Tree-inspired metaphors—roots for self-care, trunk for growth, branches for learning and relationships, and fruit for creative expression.
+- **Calm aesthetic:** Soft colour palette (muted blues/greens, warm neutrals), rounded edges, and minimal clutter.
+- **Accessible & responsive:** Mobile-first design, smooth transitions, and readable typography.
+
 ## Project structure
 
 ```
@@ -109,10 +187,79 @@ docker compose up --build
 | `frontend` | `npm run build`     | Build the production-ready static assets. |
 | `frontend` | `npm test`          | Launch the Jest/React Testing Library runner. |
 
-## 7. Additional notes
+## 7. API reference
 
-- **Authentication** uses JSON Web Tokens. Set `JWT_SECRET` to a strong value in production.  
-- **CORS**: update `CORS_ORIGIN` (comma-separated list) if you host the frontend on another domain.  
+All endpoints are served from the `/api` prefix and return JSON. Supply an `Authorization: Bearer <token>` header for protected routes.
+
+### Health check
+
+- `GET /api/health` – Lightweight probe to confirm the server can connect to PostgreSQL.
+
+### Authentication & profile
+
+- `POST /api/auth/register` – Create an account (defaults to the `journaler` role unless `role` is provided, mentors can include `mentorProfile`). *(Public)*
+- `POST /api/auth/login` – Exchange credentials for a JWT and hydrated profile. *(Public)*
+- `POST /api/auth/magic-link` – Stub endpoint that acknowledges a magic-link request. *(Public)*
+- `GET /api/auth/me` – Return the authenticated user profile, including mentor metadata when applicable. *(Authenticated)*
+- `PATCH /api/auth/me` – Update name, timezone, notification preferences, password, and mentor profile fields. *(Authenticated)*
+- `GET /api/auth/mentor/profiles` – List mentor profiles for administrative review. *(Admin only)*
+
+### Form library
+
+- `GET /api/forms/default` – Fetch the default "Daily Roots Check-In" journaling form. *(Public)*
+- `GET /api/forms` – Return forms visible to the current user (defaults, assigned mentor forms, or the full catalogue for admins). *(Authenticated)*
+- `POST /api/forms` – Create a reusable journaling form; mentors create `mentor`-visible templates, admins may publish `admin` forms. *(Mentor or admin)*
+- `POST /api/forms/:formId/assign` – Assign a form to a journaler; mentors must already be linked to the journaler. *(Mentor or admin)*
+- `DELETE /api/forms/:formId/assign/:journalerId` – Remove a form assignment from a journaler. *(Mentor or admin)*
+
+### Journal entries
+
+- `POST /api/journal-entries` – Submit a journal entry, automatically normalising mood, building a summary, and notifying linked mentors according to the share level. *(Journaler)*
+- `GET /api/journal-entries` – Journalers retrieve their own history (with optional `limit`); mentors provide `journalerId` to view non-private entries for linked mentees. *(Authenticated)*
+- `GET /api/journal-entries/:id` – Fetch a single entry; access is limited to the author or linked mentors when the entry is shared beyond `private`. *(Authenticated)*
+- `GET /api/journal-entries/:id/comments` – List mentor comments attached to an entry. *(Authenticated)*
+- `POST /api/journal-entries/:id/comments` – Add a mentor comment to a shared entry for a linked journaler. *(Mentor)*
+
+### Mentorship workflows
+
+- `GET /api/mentors` – Search mentors by name, email, or expertise using the `q` query parameter. *(Authenticated)*
+- `GET /api/mentors/requests` – View mentorship requests relevant to the signed-in mentor or journaler. *(Authenticated)*
+- `POST /api/mentors/requests` – Journalers request a mentor (prevents self-selection and duplicate links). *(Journaler)*
+- `POST /api/mentors/requests/:id/accept` – Mentors acknowledge a pending request. *(Mentor)*
+- `POST /api/mentors/requests/:id/confirm` – Journalers confirm an accepted request, establishing a mentor link. *(Journaler)*
+- `POST /api/mentors/requests/:id/decline` – Decline a request as the involved mentor or journaler. *(Authenticated)*
+- `GET /api/mentors/mentees` – Display linked journalers with their latest shared reflections. *(Mentor)*
+- `GET /api/mentors/notifications` – Retrieve the 50 most recent entry notifications shared by mentees. *(Mentor)*
+- `POST /api/mentors/notifications/:id/read` – Mark a notification as reviewed. *(Mentor)*
+
+### Dashboards & analytics
+
+- `GET /api/dashboard/journaler` – Aggregate streaks, average mood, highlights, and trend data for the journaler dashboard. *(Journaler)*
+- `GET /api/dashboard/mentor` – Surface mentee trends, risk alerts, and activity indicators for mentors. *(Mentor)*
+
+### Administration
+
+- `GET /api/admin/overview` – Platform-level counts of users, forms, entries, mentor links, and pending requests. *(Admin)*
+- `GET /api/admin/forms` – Review the full form library with assignment counts and creators. *(Admin)*
+- `PATCH /api/admin/forms/:id` – Update form visibility, description, or default status. *(Admin)*
+- `GET /api/admin/mentors` – List mentors with profile details and mentee counts. *(Admin)*
+
+## 8. Troubleshooting
+
+- **Database connection errors** – Confirm PostgreSQL is running, the credentials in `DATABASE_URL` are valid, and set `DATABASE_SSL=true` only when the server requires TLS. The backend will log "Database unreachable" if the health check fails.
+- **Schema missing after first boot** – Ensure the database user has permissions to create tables. `initializePlatform` runs automatically on startup and seeds the default form and admin account when credentials are provided.
+- **Requests blocked by CORS** – Update `CORS_ORIGIN` with the frontend origin (comma-separated for multiple hosts) so browsers can call the API successfully.
+- **Unexpected 401/403 responses** – Verify the frontend is attaching the JWT in the `Authorization` header and that the account role matches the endpoint (e.g. admin routes require `admin`). Clearing the stored session in localStorage can resolve stale tokens.
+- **Mentors cannot assign forms** – Mentors must first confirm a mentorship link with the journaler; otherwise the `/forms/:id/assign` route returns `403`.
+
+## 9. Additional notes
+
+- **Authentication** uses JSON Web Tokens. Set `JWT_SECRET` to a strong value in production.
+- **CORS**: update `CORS_ORIGIN` (comma-separated list) if you host the frontend on another domain.
 - **Notifications & defaults**: new users receive default notification preferences defined in `DEFAULT_NOTIFICATION_PREFS`. Adjust in `backend/utils/bootstrap.js` if you need different defaults.
 
 With these steps Aleya should be fully operational for local development or evaluation.
+
+## 10. Project wiki
+
+See [docs/wiki.md](docs/wiki.md) for frontend specifications, backend internals, and architecture notes.

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -1,0 +1,51 @@
+# Aleya Project Wiki
+
+## Architecture overview
+
+- **Monorepo layout** – `backend/` hosts the Express API, `frontend/` contains the React client, and `docker-compose.yml` wires both services for local development convenience.
+- **Server entry point** – `backend/index.js` configures CORS, JSON parsing, and mounts route modules under the `/api` prefix before bootstrapping the database and starting the HTTP server.
+- **Database connectivity** – `backend/db.js` uses `pg`'s pooled client with SSL opt-in via `DATABASE_SSL`, logging an initial connectivity check when the app boots.
+- **Bootstrap lifecycle** – `initializePlatform` in `backend/utils/bootstrap.js` ensures schema creation, seeds the default "Daily Roots Check-In" form, and optionally provisions an administrator based on environment variables.
+- **Shared environment** – both apps load `.env` files; the frontend consumes `REACT_APP_API_URL` while the backend expects `DATABASE_URL`, `CORS_ORIGIN`, `JWT_SECRET`, and optional seeding credentials.
+- **Deployment considerations** – the Express API exposes HTTP on `PORT` (default `5000`) and the React app on `3000`; Docker images leverage Node 18+ and can be orchestrated via the provided compose file.
+
+## Frontend specifications
+
+### Tech stack & structure
+
+- **Libraries** – React 19 with `react-router-dom` 6 for routing, `date-fns` for formatting, and Testing Library packages for unit tests.
+- **Directory roles** – `src/api` contains a thin `fetch` wrapper, `src/context` offers shared auth state, `src/components` houses reusable UI building blocks, and `src/pages` implements route-level screens.
+- **Routing shell** – `App.js` wires `AuthProvider` around `BrowserRouter`, protecting routes by role and rendering dashboards based on the authenticated user's role.
+- **Layout** – `components/Layout.js` renders navigation links tailored to the active role and exposes authentication actions in the header.
+- **Authentication state** – `context/AuthContext.js` persists JWTs and user profiles to `localStorage`, provides login/register helpers, and exposes profile mutation utilities.
+
+### Key user journeys
+
+- **Journalers** – `pages/JournalerDashboard.js` fetches available forms, metrics, and entry history; `JournalEntryForm` dynamically renders fields, validates required prompts, controls share levels, and submits entries to `/journal-entries`.
+- **Mentors** – `pages/MentorDashboard.js` aggregates mentee mood trends, low-mood/crisis alerts, pending requests, and entry notifications while allowing accept/confirm/decline actions.
+- **Admins** – `pages/AdminDashboard.js` displays platform metrics, the form catalogue, and mentor directory using aggregated admin endpoints.
+- **Navigation** – additional pages (e.g. `MentorConnectionsPage`, `JournalHistoryPage`, `SettingsPage`) use the shared API client for CRUD flows around mentorship links, journaling history, and profile updates.
+
+## Backend specifications
+
+### Tech stack & modules
+
+- **Framework** – Express 5 with middleware for CORS, JSON parsing, authentication (`middleware/auth.js`), and role checks (`middleware/requireRole.js`).
+- **Data access** – PostgreSQL via `pg` using pooled queries; helpers in `utils/metrics.js` and `utils/mood.js` compute streaks, trends, and mood messaging for dashboards.
+- **Routing** – modular route files (auth, forms, mentors, journal, dashboard, admin) mounted in `index.js`, each employing `express-validator` for payload validation and consistent error handling.
+
+### Data model
+
+- **Core tables** – `users`, `mentor_profiles`, `mentor_requests`, `mentor_links`, `journal_forms`, `journal_form_fields`, `mentor_form_assignments`, `journal_entries`, `mentor_notifications`, and `entry_comments` are created automatically during bootstrap.
+- **Defaults** – the bootstrap routine seeds notification preferences and the "Daily Roots Check-In" form (with mood, reflection, and wellbeing fields) and can create a default admin when `SEED_ADMIN_*` variables are set.
+- **Indexes** – targeted indexes on journal entries, mentor notifications, and form assignments support frequent lookups in dashboards and mentorship flows.
+
+### API responsibilities
+
+- **Authentication** – registration hashes passwords, supports optional mentor profiles, returns JWTs, and exposes profile update endpoints.
+- **Form management** – mentors and admins can create and assign forms, while journalers retrieve the default and assigned prompts; assignments enforce confirmed mentorship links.
+- **Journaling** – journalers submit entries with share levels; mentors view mentee entries according to visibility, leave comments, and receive notifications.
+- **Mentorship** – search mentors, manage request lifecycle (request, accept, confirm, decline), maintain mentor/journaler links, and surface mentee summaries.
+- **Dashboards** – provide role-specific analytics by combining journal data with mood scoring and crisis keyword detection.
+- **Administration** – expose overview metrics, form catalogue management, and mentor directory endpoints restricted to admins.
+


### PR DESCRIPTION
## Summary
- add a product overview section to the README that captures vision, roles, and core features
- document end-to-end user flows plus privacy, control, and design principles for the Aleya platform

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68c8cb399bdc8333a7451611a6953293