### PR TITLE
Avoid sending null JSON bodies

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -9,7 +9,7 @@ async function request(path, { method = "GET", data, token, headers = {} } = {})
     },
   };
 
-  if (data !== undefined) {
+  if (data !== undefined && data !== null) {
     config.body = JSON.stringify(data);
   }
 


### PR DESCRIPTION
## Summary
- skip JSON serialization when a request payload is null so empty POSTs don't send the literal string `null`
- prevent mentor request actions from triggering backend JSON parsing errors

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c8d1fe54f483338c3852bcd04b6bb9