### PR TITLE
Add centralized logging and document log usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+!/backend/.env
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Before running Aleya locally make sure you have:
 
 ## 1. Configure environment variables
 
-Create `backend/.env` with the following variables:
+Update `backend/.env` (a sample file is checked into the repo) with the following variables:
 
 ```
 DATABASE_URL=postgres://<user>:<password>@<host>:<port>/<database>
@@ -109,6 +109,12 @@ DATABASE_SSL=false        # set to true only when your database requires SSL
 PORT=5000
 CORS_ORIGIN=http://localhost:3000
 JWT_SECRET=super-secret-value
+
+# Logging configuration
+LOG_FILE=logs/aleya.log
+LOG_LEVEL=info
+LOG_MAX_SIZE=5242880
+LOG_MAX_FILES=5
 
 # Optional: seed a default administrator account on startup
 SEED_ADMIN_EMAIL=admin@example.com
@@ -126,6 +132,7 @@ SMTP_SECURE=false
 
 - `DATABASE_URL` is required so the API can connect to PostgreSQL. The backend tests the connection on boot and will fail if it cannot reach the database.
 - `initializePlatform` automatically applies the SQL schema, ensures the default journaling form exists, and (optionally) seeds the admin user when the server starts.
+- `LOG_FILE`, `LOG_LEVEL`, `LOG_MAX_SIZE`, and `LOG_MAX_FILES` configure structured logging. Paths supplied in `LOG_FILE` are resolved relative to `backend/` unless absolute; rotation kicks in once the file size limit is reached.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, and `SMTP_FROM` configure the SMTP server used for notification emails. The backend validates these settings during start-up and will exit with a descriptive error if any value is missing or malformed.
 - Set `SMTP_SECURE=true` when connecting to port 465 or any server that requires an implicit TLS connection. For ports that upgrade via STARTTLS (such as 587) leave it as `false`.
 
@@ -174,6 +181,16 @@ npm start
 ```
 
 By default the frontend runs on `http://localhost:3000` and proxies API calls to `REACT_APP_API_URL`.
+
+## Logging
+
+The backend emits structured JSON logs via [Winston](https://github.com/winstonjs/winston). Messages are written both to stdout and to the file configured by `LOG_FILE` (default `backend/logs/aleya.log`). To follow the log file during development:
+
+```bash
+tail -f backend/logs/aleya.log
+```
+
+If you customise `LOG_FILE` in `.env`, the logger will create the directory automatically. Log rotation is controlled by `LOG_MAX_SIZE` (bytes) and `LOG_MAX_FILES`.
 
 ## 5. Running with Docker (optional)
 

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,25 @@
+# Core database configuration
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/aleya
+DATABASE_SSL=false
+PORT=5000
+CORS_ORIGIN=http://localhost:3000
+JWT_SECRET=development-secret
+
+# Logging configuration
+LOG_FILE=logs/aleya.log
+LOG_LEVEL=info
+LOG_MAX_SIZE=5242880
+LOG_MAX_FILES=5
+
+# Optional: seed a default administrator account
+SEED_ADMIN_EMAIL=
+SEED_ADMIN_PASSWORD=
+SEED_ADMIN_NAME=Aleya Admin
+
+# SMTP configuration (required for outbound email)
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-username
+SMTP_PASSWORD=your-smtp-password
+SMTP_FROM="Aleya <no-reply@example.com>"
+SMTP_SECURE=false

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,5 +1,13 @@
 const { Pool } = require("pg");
 
+const { logger, serializeError } = require("./utils/logger");
+
+if (!process.env.DATABASE_URL) {
+  const error = new Error("DATABASE_URL environment variable is not defined");
+  logger.error(error.message);
+  throw error;
+}
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl:
@@ -13,15 +21,15 @@ pool
   .then(async (client) => {
     try {
       const res = await client.query("SELECT NOW()");
-      console.log("DB connected! Server time:", res.rows[0].now);
+      logger.info("Connected to database. Server time: %s", res.rows[0].now);
     } catch (error) {
-      console.error("DB test query error:", error.stack);
+      logger.error("DB test query error", { error: serializeError(error) });
     } finally {
       client.release();
     }
   })
   .catch((error) => {
-    console.error("DB connection error:", error.stack);
+    logger.error("DB connection error", { error: serializeError(error) });
   });
 
 module.exports = pool;

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
 const pool = require("../db");
+const { logger } = require("../utils/logger");
 
 const JWT_SECRET = process.env.JWT_SECRET || "development-secret";
 
@@ -39,7 +40,12 @@ module.exports = async function authenticate(req, res, next) {
     req.user = user;
     return next();
   } catch (error) {
-    console.error("Auth error:", error.message);
+    logger.warn(
+      "Authentication error on %s: %s (%s)",
+      req.originalUrl,
+      error.message,
+      error.name
+    );
     return res.status(401).json({ error: "Invalid or expired token" });
   }
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,11 +15,38 @@
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
-        "pg": "^8.16.3"
+        "pg": "^8.16.3",
+        "winston": "^3.17.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
       }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -47,6 +74,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -187,6 +220,51 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -313,6 +391,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -422,6 +506,12 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -451,6 +541,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -649,6 +745,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -701,6 +803,18 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -743,6 +857,12 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -791,6 +911,23 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -950,6 +1087,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/parseurl": {
@@ -1187,6 +1333,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1235,6 +1395,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1369,6 +1538,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1391,6 +1569,15 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1398,6 +1585,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/supports-color": {
@@ -1412,6 +1608,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1445,6 +1647,15 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1475,6 +1686,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/validator": {
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
@@ -1491,6 +1708,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/utils/bootstrap.js
+++ b/backend/utils/bootstrap.js
@@ -1,5 +1,6 @@
 const bcrypt = require("bcryptjs");
 const pool = require("../db");
+const { logger } = require("./logger");
 const { MOOD_OPTIONS } = require("./mood");
 
 const DEFAULT_NOTIFICATION_PREFS = {
@@ -264,7 +265,7 @@ async function ensureAdminAccount() {
      VALUES ($1, $2, $3, 'admin')`,
     [email.toLowerCase(), passwordHash, name]
   );
-  console.log("Seeded default admin account", email);
+  logger.info("Seeded default admin account for %s", email);
 }
 
 async function initializePlatform() {

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,0 +1,97 @@
+const fs = require("fs");
+const path = require("path");
+const { createLogger, format, transports } = require("winston");
+
+const resolvedLogFile = path.resolve(
+  __dirname,
+  "..",
+  process.env.LOG_FILE || "logs/aleya.log"
+);
+
+const logDirectory = path.dirname(resolvedLogFile);
+if (!fs.existsSync(logDirectory)) {
+  fs.mkdirSync(logDirectory, { recursive: true });
+}
+
+const fileTransport = new transports.File({
+  filename: resolvedLogFile,
+  maxsize: parseInt(process.env.LOG_MAX_SIZE || "5242880", 10), // 5 MB
+  maxFiles: parseInt(process.env.LOG_MAX_FILES || "5", 10),
+});
+
+const consoleTransport = new transports.Console({
+  format: format.combine(
+    format.colorize(),
+    format.timestamp(),
+    format.errors({ stack: true }),
+    format.splat(),
+    format.printf((info) => {
+      const { timestamp, level, message, stack } = info;
+      const splat = info[Symbol.for("splat")] || [];
+      const splatString = splat
+        .map((value) =>
+          typeof value === "object"
+            ? JSON.stringify(value, null, 2)
+            : String(value)
+        )
+        .join(" ");
+
+      const meta = { ...info };
+      delete meta.timestamp;
+      delete meta.level;
+      delete meta.message;
+      delete meta.stack;
+
+      const metaKeys = Object.keys(meta);
+      const metaString = metaKeys.length
+        ? ` ${JSON.stringify(
+            metaKeys.reduce((acc, key) => ({ ...acc, [key]: meta[key] }), {})
+          )}`
+        : "";
+
+      const baseMessage = stack || message;
+      const extras = splatString ? ` ${splatString}` : "";
+
+      return `${timestamp} ${level}: ${baseMessage}${extras}${metaString}`;
+    })
+  ),
+});
+
+const logger = createLogger({
+  level: process.env.LOG_LEVEL || "info",
+  format: format.combine(
+    format.timestamp(),
+    format.errors({ stack: true }),
+    format.splat(),
+    format.json()
+  ),
+  transports: [fileTransport, consoleTransport],
+});
+
+logger.stream = {
+  write(message) {
+    logger.info(message.trim());
+  },
+};
+
+function serializeError(error) {
+  if (!error) {
+    return undefined;
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+    };
+  }
+
+  return error;
+}
+
+module.exports = {
+  logger,
+  resolvedLogFile,
+  serializeError,
+};


### PR DESCRIPTION
## Summary
- add a Winston-based logger utility and replace console logging across the backend
- provide default logging configuration via `backend/.env` and document how to inspect log files

## Testing
- not run (not requested)

