### PR TITLE
Require email verification during signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ All endpoints are served from the `/api` prefix and return JSON. Supply an `Auth
 
 ### Authentication & profile
 
-- `POST /api/auth/register` – Create an account (defaults to the `journaler` role unless `role` is provided, mentors can include `mentorProfile`). *(Public)*
+- `POST /api/auth/register` – Create a journaler or mentor account and trigger a verification email. *(Public)*
+- `POST /api/auth/verify-email` – Confirm a pending account using the emailed token. *(Public)*
 - `POST /api/auth/login` – Exchange credentials for a JWT and hydrated profile. *(Public)*
 - `POST /api/auth/magic-link` – Stub endpoint that acknowledges a magic-link request. *(Public)*
 - `GET /api/auth/me` – Return the authenticated user profile, including mentor metadata when applicable. *(Authenticated)*

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.14",
         "pg": "^8.16.3",
         "winston": "^3.17.0"
       },
@@ -1006,6 +1007,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
+    "nodemailer": "^6.9.14",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "winston": "^3.17.0"

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,20 +1,133 @@
 const express = require("express");
 const bcrypt = require("bcryptjs");
+const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
+const nodemailer = require("nodemailer");
 const { body, validationResult } = require("express-validator");
 const pool = require("../db");
 const authenticate = require("../middleware/auth");
 const requireRole = require("../middleware/requireRole");
 const { DEFAULT_NOTIFICATION_PREFS } = require("../utils/bootstrap");
+const { logger } = require("../utils/logger");
 
 const router = express.Router();
 
 const JWT_SECRET = process.env.JWT_SECRET || "development-secret";
-const ALLOWED_ROLES = ["journaler", "mentor", "admin"];
+const REGISTER_ROLES = ["journaler", "mentor"];
+
+const DEFAULT_VERIFICATION_TOKEN_TTL_HOURS = 48;
+
+function resolveVerificationTtlHours() {
+  const raw = process.env.EMAIL_VERIFICATION_TTL_HOURS;
+  if (!raw) {
+    return DEFAULT_VERIFICATION_TOKEN_TTL_HOURS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_VERIFICATION_TOKEN_TTL_HOURS;
+  }
+
+  return parsed;
+}
+
+const VERIFICATION_TOKEN_TTL_HOURS = resolveVerificationTtlHours();
+
+function getMailTransporter(app) {
+  if (!app?.locals?.mailSettings) {
+    throw new Error("Mail settings are not configured");
+  }
+
+  if (!app.locals.mailTransporter) {
+    app.locals.mailTransporter = nodemailer.createTransport(
+      app.locals.mailSettings
+    );
+  }
+
+  return app.locals.mailTransporter;
+}
+
+function buildVerificationLink(token) {
+  const explicit = process.env.EMAIL_VERIFICATION_URL;
+
+  if (explicit) {
+    try {
+      const url = new URL(explicit);
+      url.searchParams.set("token", token);
+      return url.toString();
+    } catch (error) {
+      logger.warn("Invalid EMAIL_VERIFICATION_URL configured: %s", explicit, {
+        error: error.message,
+      });
+    }
+  }
+
+  const fallbackBase =
+    process.env.APP_BASE_URL ||
+    process.env.FRONTEND_URL ||
+    (process.env.CORS_ORIGIN
+      ? process.env.CORS_ORIGIN.split(",")[0].trim()
+      : null) ||
+    "http://localhost:3000";
+
+  try {
+    const baseUrl = new URL(fallbackBase);
+    const trimmedPath = baseUrl.pathname.replace(/\/$/, "");
+    baseUrl.pathname = `${trimmedPath}/verify-email`;
+    baseUrl.searchParams.set("token", token);
+    return baseUrl.toString();
+  } catch (error) {
+    return `http://localhost:3000/verify-email?token=${encodeURIComponent(
+      token
+    )}`;
+  }
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function sendVerificationEmail(app, { email, name }, token) {
+  const transporter = getMailTransporter(app);
+  const verificationUrl = buildVerificationLink(token);
+
+  const displayName = name ? name.trim() : "there";
+  const safeName = escapeHtml(displayName || "there");
+  const expiresText =
+    VERIFICATION_TOKEN_TTL_HOURS === 1
+      ? "1 hour"
+      : `${VERIFICATION_TOKEN_TTL_HOURS} hours`;
+
+  await transporter.sendMail({
+    to: email,
+    from: app.locals.mailSettings.from,
+    subject: "Verify your Aleya email address",
+    text: `Hi ${displayName || "there"},\n\n` +
+      "Thanks for joining Aleya. Please confirm your email address by visiting the link below:\n" +
+      `${verificationUrl}\n\n` +
+      `The link expires in ${expiresText}. If you didn't create an account, you can safely ignore this message.\n\n` +
+      "Rooted in care,\nThe Aleya team",
+    html: `<p>Hi ${safeName},</p>` +
+      `<p>Thanks for joining Aleya. Please confirm your email address by clicking the button below.</p>` +
+      `<p><a href="${verificationUrl}" style="display:inline-block;padding:12px 20px;background:#2f855a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">Verify email</a></p>` +
+      `<p>This link expires in ${escapeHtml(
+        expiresText
+      )}. If you didn't create an account you can safely ignore this email.</p>` +
+      `<p>Rooted in care,<br/>The Aleya team</p>`,
+  });
+
+  logger.info("Sent verification email to %s", email);
+}
 
 async function fetchUserById(id) {
   const { rows } = await pool.query(
     `SELECT u.id, u.email, u.name, u.role, u.timezone, u.notification_preferences,
+            u.is_verified,
             mp.expertise, mp.availability, mp.bio
      FROM users u
      LEFT JOIN mentor_profiles mp ON mp.user_id = u.id
@@ -52,6 +165,7 @@ async function fetchUserById(id) {
     name: row.name,
     role: row.role,
     timezone: row.timezone,
+    isVerified: row.is_verified,
     notificationPreferences,
   };
 
@@ -83,10 +197,16 @@ router.post(
     body("password")
       .isLength({ min: 8 })
       .withMessage("Password must be at least 8 characters"),
+    body("confirmPassword")
+      .notEmpty()
+      .withMessage("Please retype your password")
+      .bail()
+      .custom((value, { req }) => value === req.body.password)
+      .withMessage("Passwords must match"),
     body("name").trim().notEmpty().withMessage("Name is required"),
     body("role")
       .optional()
-      .isIn(ALLOWED_ROLES)
+      .isIn(REGISTER_ROLES)
       .withMessage("Invalid role"),
   ],
   async (req, res, next) => {
@@ -103,7 +223,8 @@ router.post(
     } = req.body;
 
     const normalizedEmail = email.toLowerCase();
-    const role = requestedRole && ALLOWED_ROLES.includes(requestedRole)
+    const role =
+      requestedRole && REGISTER_ROLES.includes(requestedRole)
       ? requestedRole
       : "journaler";
 
@@ -121,9 +242,28 @@ router.post(
       }
 
       const passwordHash = await bcrypt.hash(password, 10);
+      const verificationToken = crypto.randomBytes(32).toString("hex");
+      const verificationTokenHash = crypto
+        .createHash("sha256")
+        .update(verificationToken)
+        .digest("hex");
+      const verificationExpiresAt = new Date(
+        Date.now() + VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000
+      );
+
       const inserted = await client.query(
-        `INSERT INTO users (email, password_hash, name, role, timezone, notification_preferences)
-         VALUES ($1, $2, $3, $4, $5, $6)
+        `INSERT INTO users (
+            email,
+            password_hash,
+            name,
+            role,
+            timezone,
+            notification_preferences,
+            is_verified,
+            verification_token_hash,
+            verification_token_expires_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, FALSE, $7, $8)
          RETURNING id`,
         [
           normalizedEmail,
@@ -132,6 +272,8 @@ router.post(
           role,
           timezone || "UTC",
           JSON.stringify(DEFAULT_NOTIFICATION_PREFS),
+          verificationTokenHash,
+          verificationExpiresAt,
         ]
       );
 
@@ -157,14 +299,21 @@ router.post(
         );
       }
 
+      await sendVerificationEmail(
+        req.app,
+        { email: normalizedEmail, name },
+        verificationToken
+      );
+
       await client.query("COMMIT");
 
-      const user = await fetchUserById(userId);
-      const token = jwt.sign({ id: user.id, role: user.role }, JWT_SECRET, {
-        expiresIn: "7d",
+      return res.status(201).json({
+        message:
+          "Account created. Please verify your email address to complete registration.",
+        email: normalizedEmail,
+        verificationExpiresAt: verificationExpiresAt.toISOString(),
+        verificationExpiresInHours: VERIFICATION_TOKEN_TTL_HOURS,
       });
-
-      return res.status(201).json({ token, user });
     } catch (error) {
       await client.query("ROLLBACK");
       return next(error);
@@ -188,7 +337,7 @@ router.post(
 
     try {
       const { rows } = await pool.query(
-        `SELECT id, password_hash FROM users WHERE email = $1`,
+        `SELECT id, password_hash, is_verified FROM users WHERE email = $1`,
         [normalizedEmail]
       );
 
@@ -203,12 +352,100 @@ router.post(
         return res.status(401).json({ error: "Invalid credentials" });
       }
 
+      if (userRow.is_verified === false) {
+        return res
+          .status(403)
+          .json({ error: "Please verify your email before signing in." });
+      }
+
       const user = await fetchUserById(userRow.id);
       const token = jwt.sign({ id: user.id, role: user.role }, JWT_SECRET, {
         expiresIn: "7d",
       });
 
       return res.json({ token, user });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.post(
+  "/verify-email",
+  [body("token").trim().notEmpty().withMessage("Verification token is required")],
+  async (req, res, next) => {
+    if (!handleValidation(req, res)) return;
+
+    const { token } = req.body;
+    const tokenHash = crypto
+      .createHash("sha256")
+      .update(token)
+      .digest("hex");
+
+    try {
+      const { rows } = await pool.query(
+        `SELECT id, email, name, is_verified, verification_token_expires_at
+         FROM users
+         WHERE verification_token_hash = $1`,
+        [tokenHash]
+      );
+
+      if (!rows.length) {
+        return res
+          .status(400)
+          .json({ error: "Invalid or expired verification link." });
+      }
+
+      const user = rows[0];
+
+      if (user.is_verified) {
+        await pool.query(
+          `UPDATE users
+             SET verification_token_hash = NULL,
+                 verification_token_expires_at = NULL,
+                 updated_at = NOW()
+           WHERE id = $1`,
+          [user.id]
+        );
+
+        return res.json({
+          message: "Email already verified. You can sign in.",
+        });
+      }
+
+      const expiresAt = user.verification_token_expires_at
+        ? new Date(user.verification_token_expires_at)
+        : null;
+
+      if (!expiresAt || Number.isNaN(expiresAt.getTime())) {
+        return res.status(400).json({
+          error:
+            "Verification link has expired. Please register again to receive a new link.",
+        });
+      }
+
+      if (expiresAt.getTime() < Date.now()) {
+        return res.status(400).json({
+          error:
+            "Verification link has expired. Please register again to receive a new link.",
+        });
+      }
+
+      await pool.query(
+        `UPDATE users
+           SET is_verified = TRUE,
+               verification_token_hash = NULL,
+               verification_token_expires_at = NULL,
+               updated_at = NOW()
+         WHERE id = $1`,
+        [user.id]
+      );
+
+      logger.info("Verified email for %s", user.email);
+
+      return res.json({
+        message: "Email verified. You can now sign in.",
+      });
     } catch (error) {
       return next(error);
     }

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -8,6 +8,9 @@ CREATE TABLE IF NOT EXISTS users (
   role TEXT NOT NULL CHECK (role IN ('journaler','mentor','admin')),
   timezone TEXT DEFAULT 'UTC',
   notification_preferences JSONB DEFAULT '{"reminders":{"daily":true,"weekly":true},"mentorNotifications":"summary"}',
+  is_verified BOOLEAN DEFAULT FALSE,
+  verification_token_hash TEXT,
+  verification_token_expires_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import MentorConnectionsPage from "./pages/MentorConnectionsPage";
 import JournalHistoryPage from "./pages/JournalHistoryPage";
 import FormBuilderPage from "./pages/FormBuilderPage";
 import SettingsPage from "./pages/SettingsPage";
+import VerifyEmailPage from "./pages/VerifyEmailPage";
 import LoadingState from "./components/LoadingState";
 import "./App.css";
 
@@ -64,6 +65,7 @@ function AppRoutes() {
           path="/register"
           element={user ? <Navigate to="/dashboard" replace /> : <RegisterPage />}
         />
+        <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route
           path="/dashboard"
           element={

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -55,8 +55,7 @@ export function AuthProvider({ children }) {
     setState((prev) => ({ ...prev, error: null }));
     try {
       const data = await apiClient.post("/auth/register", payload);
-      persist(data.token, data.user);
-      return data.user;
+      return data;
     } catch (error) {
       setState((prev) => ({ ...prev, error: error.message }));
       throw error;

--- a/frontend/src/pages/VerifyEmailPage.js
+++ b/frontend/src/pages/VerifyEmailPage.js
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import apiClient from "../api/client";
+
+function VerifyEmailPage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState(token ? "pending" : "missing");
+  const [message, setMessage] = useState(
+    token ? "Verifying your email..." : "No verification token found."
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!token) {
+      return undefined;
+    }
+
+    const verify = async () => {
+      setStatus("pending");
+      setMessage("Verifying your email...");
+      try {
+        const response = await apiClient.post("/auth/verify-email", { token });
+        if (cancelled) return;
+        setMessage(response?.message || "Email verified. You can now sign in.");
+        setStatus("success");
+      } catch (error) {
+        if (cancelled) return;
+        setMessage(error.message);
+        setStatus("error");
+      }
+    };
+
+    verify();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const renderContent = () => {
+    switch (status) {
+      case "pending":
+        return (
+          <>
+            <p className="page-subtitle">{message}</p>
+            <p className="info-text">This will only take a moment.</p>
+          </>
+        );
+      case "success":
+        return (
+          <>
+            <p className="page-subtitle">{message}</p>
+            <Link to="/login" className="primary-button">
+              Continue to sign in
+            </Link>
+          </>
+        );
+      case "error":
+        return (
+          <>
+            <p className="form-error">{message}</p>
+            <p className="info-text">
+              Need a new link? Register again with your email to receive another
+              verification message.
+            </p>
+            <div>
+              <Link to="/login" className="ghost-button">
+                Return to sign in
+              </Link>
+              <Link to="/register" className="primary-button">
+                Register again
+              </Link>
+            </div>
+          </>
+        );
+      case "missing":
+      default:
+        return (
+          <>
+            <p className="form-error">{message}</p>
+            <p className="info-text">
+              Double-check the link in your email or start a new registration to
+              receive a fresh one.
+            </p>
+            <Link to="/register" className="primary-button">
+              Register
+            </Link>
+          </>
+        );
+    }
+  };
+
+  const heading =
+    status === "success"
+      ? "You're verified!"
+      : status === "error"
+      ? "Verification issue"
+      : "Verify your email";
+
+  return (
+    <div className="auth-page">
+      <h1>{heading}</h1>
+      {renderContent()}
+    </div>
+  );
+}
+
+export default VerifyEmailPage;


### PR DESCRIPTION
## Summary
- generate and store hashed email verification tokens during registration, send verification links via nodemailer, and block logins until an address is confirmed
- extend the schema/bootstrap logic with verification columns and ensure the seeded admin account is marked verified
- update the React registration flow to collect a confirmation password, show post-signup guidance, and add a verification landing page; document the new endpoint in the README

## Testing
- npm run build