### PR TITLE
Remove magic link functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Aleya is a journaling and mentorship platform that pairs reflective journaling t
 ### Core features (MVP)
 
 - **Journal entry forms:** A collection of customizable forms rather than a single template. The default form captures mood (happy, loved, proud, relaxed, tired, anxious, angry, sad), the causes of today's emotions, and learnings. Optional fields include sleep, energy, and activities. Mentors can assign additional or specialised forms after both parties confirm the mentorship link.
-- **Authentication:** Email + password or a magic-link flow.
+- **Authentication:** Email + password with email verification.
 - **Mentor linking:** Journalers can invite or select mentors, forming a mentorship connection only after mutual consent.
 - **Reminders:** Daily or weekly reminders delivered via email.
 - **Mentor notifications:** Email summaries of mentee entries with privacy controls to respect journaler choices.
@@ -227,7 +227,6 @@ All endpoints are served from the `/api` prefix and return JSON. Supply an `Auth
 - `POST /api/auth/register` – Create a journaler or mentor account and trigger a verification email. *(Public)*
 - `POST /api/auth/verify-email` – Confirm a pending account using the emailed token. *(Public)*
 - `POST /api/auth/login` – Exchange credentials for a JWT and hydrated profile. *(Public)*
-- `POST /api/auth/magic-link` – Stub endpoint that acknowledges a magic-link request. *(Public)*
 - `GET /api/auth/me` – Return the authenticated user profile, including mentor metadata when applicable. *(Authenticated)*
 - `PATCH /api/auth/me` – Update name, timezone, notification preferences, password, and mentor profile fields. *(Authenticated)*
 - `GET /api/auth/mentor/profiles` – List mentor profiles for administrative review. *(Admin only)*

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -452,21 +452,6 @@ router.post(
   }
 );
 
-router.post(
-  "/magic-link",
-  [body("email").isEmail().withMessage("Email is required")],
-  async (req, res) => {
-    if (!handleValidation(req, res)) return;
-
-    // The actual email delivery would be implemented with an email provider.
-    // We simply acknowledge the request for now.
-    res.json({
-      message:
-        "Magic link requested. In production this would email a secure login link.",
-    });
-  }
-);
-
 router.get("/me", authenticate, async (req, res, next) => {
   try {
     const user = await fetchUserById(req.user.id);

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -83,12 +83,6 @@ export function AuthProvider({ children }) {
     return data.user;
   };
 
-  const requestMagicLink = async (email) => {
-    if (!email) throw new Error("Email is required for magic link");
-    await apiClient.post("/auth/magic-link", { email });
-    return true;
-  };
-
   const value = {
     ...state,
     login,
@@ -96,7 +90,6 @@ export function AuthProvider({ children }) {
     logout,
     refreshProfile,
     updateProfile,
-    requestMagicLink,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -3,11 +3,10 @@ import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 
 function LoginPage() {
-  const { login, requestMagicLink, error } = useAuth();
+  const { login, error } = useAuth();
   const navigate = useNavigate();
   const [form, setForm] = useState({ email: "", password: "" });
   const [loading, setLoading] = useState(false);
-  const [magicStatus, setMagicStatus] = useState(null);
 
   const handleChange = (event) => {
     const { name, value } = event.target;
@@ -27,21 +26,11 @@ function LoginPage() {
     }
   };
 
-  const handleMagicLink = async () => {
-    try {
-      await requestMagicLink(form.email);
-      setMagicStatus("Magic link sent! Check your inbox.");
-    } catch (err) {
-      setMagicStatus(err.message);
-    }
-  };
-
   return (
     <div className="auth-page">
       <h1>Welcome back</h1>
       <p className="page-subtitle">
-        Continue tending your growth journey. Log in with your credentials or
-        request a magic link.
+        Continue tending your growth journey. Log in with your credentials.
       </p>
       <form className="auth-form" onSubmit={handleSubmit}>
         <label>
@@ -70,10 +59,6 @@ function LoginPage() {
           {loading ? "Signing in..." : "Sign in"}
         </button>
       </form>
-      <button type="button" className="ghost-button" onClick={handleMagicLink}>
-        Send me a magic link
-      </button>
-      {magicStatus && <p className="info-text">{magicStatus}</p>}
       <p className="info-text">
         New to Aleya? <Link to="/register">Create an account</Link>
       </p>


### PR DESCRIPTION
## Summary
- remove the unused magic-link request endpoint from the authentication router
- drop the magic-link request flow from the React auth context and login page
- update the README to describe the remaining email/password authentication paths

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests
