### PR TITLE
chore: centralize tailwind design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Aleya is a journaling and mentorship platform that pairs reflective journaling t
 └── README.md
 ```
 
+### Frontend styling system
+
+The React client uses Tailwind CSS with a small design system exposed in `frontend/src/index.css`. Buttons, form controls, and typography tokens are wrapped in named classes (e.g. `btn-primary`, `form-input`, `text-display`) and re-exported from `frontend/src/styles/ui.js` for ergonomic use inside React components.
+
 ## Prerequisites
 
 Before running Aleya locally make sure you have:

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,9 @@
+# Frontend contributor notes
+
+- Use the Tailwind utility wrappers defined in `src/index.css` (and re-exported via `src/styles/ui.js`) for all shared UI patterns.
+  - Buttons: `btn-primary`, `btn-secondary`, `btn-subtle`.
+  - Form controls: `form-input`, `form-select`, `form-textarea`, `form-checkbox`, plus their compact variants.
+  - Typography tokens: `text-display`, `text-heading-*`, `text-body*`, `text-eyebrow`, `text-caption`, `form-label`.
+  - Helper styles: `card-container`, `empty-state`, `text-info`, `text-muted`, `chip-base`, `badge-base`.
+- When composing new components, import the relevant constants from `src/styles/ui.js` instead of hard-coding class strings. This keeps the font stack and sizing consistent across the app.
+- Update this document if you introduce new design tokens so future changes remain consistent.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,70 +1,62 @@
-# Getting Started with Create React App
+# Aleya frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+The Aleya web client is a [Create React App](https://create-react-app.dev/) project that uses Tailwind CSS for layout and component styling.
 
-## Available Scripts
+## Local development
 
-In the project directory, you can run:
+```bash
+cd frontend
+npm install
+npm start
+```
 
-### `npm start`
+The development server runs on http://localhost:3000. Use `npm test` to launch the Jest test runner and `npm run build` to create a production build.
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+## Design system
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+All reusable styles live in `src/index.css` under a `@layer components` block. These classes wrap Tailwind utilities so that typography, buttons, form controls, and feedback states stay consistent across the application.
 
-### `npm test`
+### Typography
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+| Token | Description |
+| --- | --- |
+| `text-display` | Hero headlines (4xl/5xl, bold, tight tracking). |
+| `text-heading-lg`, `text-heading-md`, `text-heading-sm`, `text-heading-xs` | Section titles from 3xl down to lg weights. |
+| `text-body-lg`, `text-body`, `text-body-strong` | Paragraph copy with relaxed leading and optional emphasis. |
+| `text-body-sm`, `text-body-sm-strong`, `text-body-sm-muted` | Small copy, helper text, and compact emphasis. |
+| `text-eyebrow`, `text-caption` | Uppercase eyebrow and caption treatments. |
+| `form-label` | Standard field label styling. |
 
-### `npm run build`
+Typography tokens only control font sizing, weight, and tracking. Apply contextual colours (e.g. `text-emerald-900`, `text-white/80`) alongside these classes where required.
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### Buttons
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+| Token | Description |
+| --- | --- |
+| `btn-primary` | Primary call-to-action button with emerald background. |
+| `btn-secondary` | Secondary action with subtle border and white backdrop. |
+| `btn-subtle` | Minimal button for tertiary actions and links. |
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+### Form controls
 
-### `npm run eject`
+| Token | Description |
+| --- | --- |
+| `form-input`, `form-input-compact` | Text inputs for regular and dense layouts. |
+| `form-textarea` | Multiline journal fields. |
+| `form-select`, `form-select-compact` | Dropdowns with matching rounded styling. |
+| `form-checkbox` | Checkbox styling aligned with emerald focus rings. |
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+### Feedback & layout helpers
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+| Token | Description |
+| --- | --- |
+| `card-container` | Frosted glass card container used on dashboards. |
+| `table-header`, `table-row` | Dashboard tables with responsive grids. |
+| `chip-base`, `badge-base` | Base styling for chips and badges (tone comes from context). |
+| `empty-state`, `text-info`, `text-muted` | Empty state containers and helper copy. |
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+Refer to `src/styles/ui.js` for the exported constants and helper functions (`getMoodBadgeClasses`, `getShareChipClasses`, etc.) used throughout the component tree.
 
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+## Linting & formatting
 
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+This project relies on Prettier formatting through Tailwind's `@apply` utilities. Run `npm test` to execute the Jest suite; additional linters can be added later if needed.

--- a/frontend/src/components/JournalEntryForm.js
+++ b/frontend/src/components/JournalEntryForm.js
@@ -1,8 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import {
+  bodySmallMutedTextClasses,
+  bodySmallStrongTextClasses,
   emptyStateClasses,
+  formLabelClasses,
   infoTextClasses,
   inputClasses,
+  mediumHeadingClasses,
   primaryButtonClasses,
   selectClasses,
   textareaClasses,
@@ -85,14 +89,16 @@ function JournalEntryForm({
   return (
     <form className="space-y-5" onSubmit={handleSubmit}>
       <div>
-        <h3 className="text-xl font-semibold text-emerald-900">{form.title}</h3>
+        <h3 className={`${mediumHeadingClasses} text-emerald-900`}>
+          {form.title}
+        </h3>
         {form.description && (
           <p className={infoTextClasses}>{form.description}</p>
         )}
       </div>
       {form.fields.map((field) => (
         <div className="space-y-2" key={field.id ?? field.label}>
-          <label className="block text-sm font-semibold text-emerald-900/80">
+          <label className={`block ${formLabelClasses}`}>
             <span>
               {field.label}
               {field.required && <span className="ml-1 text-rose-500">*</span>}
@@ -102,15 +108,14 @@ function JournalEntryForm({
             )}
           </label>
           {field.helperText && (
-            <p className="text-sm text-emerald-900/60">{field.helperText}</p>
+            <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
+              {field.helperText}
+            </p>
           )}
         </div>
       ))}
       <div className="space-y-2">
-        <label
-          htmlFor="sharing"
-          className="block text-sm font-semibold text-emerald-900/80"
-        >
+        <label htmlFor="sharing" className={`block ${formLabelClasses}`}>
           Sharing preference
         </label>
         <select
@@ -125,18 +130,20 @@ function JournalEntryForm({
             </option>
           ))}
         </select>
-        <p className="text-sm text-emerald-900/60">
+        <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
           Control what mentors can see when you submit entries.
         </p>
       </div>
       {error && (
-        <p className="rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm font-semibold text-rose-600">
+        <p
+          className={`rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 ${bodySmallStrongTextClasses} text-rose-600`}
+        >
           {error}
         </p>
       )}
       {statusMessage && (
         <p
-          className={`rounded-2xl px-4 py-3 text-sm font-medium ${
+          className={`rounded-2xl px-4 py-3 ${bodySmallStrongTextClasses} ${
             statusVariant === "success"
               ? "border border-emerald-100 bg-emerald-50/80 text-emerald-700"
               : "border border-emerald-100 bg-white/80 text-emerald-900/70"

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,6 +1,10 @@
 import { NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import {
+  bodySmallMutedTextClasses,
+  bodySmallStrongTextClasses,
+  captionTextClasses,
+  largeHeadingClasses,
   primaryButtonClasses,
   secondaryButtonClasses,
   subtleButtonClasses,
@@ -44,12 +48,14 @@ function Layout({ children }) {
         <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
           <button
             type="button"
-            className="rounded-full border border-transparent bg-transparent font-display text-3xl font-semibold leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+            className={`rounded-full border border-transparent bg-transparent leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${largeHeadingClasses}`}
             onClick={() => navigate(user ? "/dashboard" : "/")}
           >
             Aleya
           </button>
-          <nav className="flex flex-1 flex-wrap items-center justify-center gap-2 text-sm font-semibold text-emerald-900/70">
+          <nav
+            className={`flex flex-1 flex-wrap items-center justify-center gap-2 ${bodySmallStrongTextClasses} text-emerald-900/70`}
+          >
             {links.map((link) => (
               <NavLink
                 key={link.to}
@@ -70,10 +76,10 @@ function Layout({ children }) {
             {user ? (
               <>
                 <div className="text-right">
-                  <span className="block text-sm font-semibold text-emerald-900">
+                  <span className={`block ${bodySmallStrongTextClasses} text-emerald-900`}>
                     {user.name}
                   </span>
-                  <span className="text-xs uppercase tracking-wide text-emerald-900/60">
+                  <span className={`${captionTextClasses} text-emerald-900/60`}>
                     {user.role}
                   </span>
                 </div>
@@ -105,7 +111,9 @@ function Layout({ children }) {
         {children}
       </main>
       <footer className="border-t border-emerald-100 bg-white/70">
-        <div className="mx-auto w-full max-w-6xl px-6 py-6 text-center text-sm text-emerald-900/70">
+        <div
+          className={`mx-auto w-full max-w-6xl px-6 py-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}
+        >
           Root your days in care, grow with guidance, and share the harvest.
         </div>
       </footer>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,3 +21,141 @@
     @apply box-border;
   }
 }
+
+@layer components {
+  .btn-primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/20 transition hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-emerald-200 bg-white/70 px-6 py-3.5 text-base font-semibold text-emerald-700 shadow-sm shadow-emerald-900/10 transition hover:-translate-y-0.5 hover:border-emerald-300 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
+  }
+
+  .btn-subtle {
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent px-4 py-2.5 text-sm font-semibold text-emerald-700 transition hover:-translate-y-0.5 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
+  }
+
+  .form-input {
+    @apply mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
+  }
+
+  .form-input-compact {
+    @apply w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-2.5 text-sm text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
+  }
+
+  .form-textarea {
+    @apply mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
+  }
+
+  .form-select {
+    @apply mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
+  }
+
+  .form-select-compact {
+    @apply w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-2.5 text-sm text-emerald-900 shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
+  }
+
+  .form-checkbox {
+    @apply h-5 w-5 rounded-md border-emerald-200 text-emerald-600 focus:ring-emerald-500;
+  }
+
+  .text-info {
+    @apply text-sm text-emerald-900/70;
+  }
+
+  .text-muted {
+    @apply text-sm text-emerald-900/60;
+  }
+
+  .empty-state {
+    @apply rounded-2xl border border-emerald-100 bg-white/60 p-6 text-center text-sm font-medium text-emerald-900/70;
+  }
+
+  .chip-base {
+    @apply inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700;
+  }
+
+  .badge-base {
+    @apply inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold capitalize tracking-wide;
+  }
+
+  .table-header {
+    @apply grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 text-sm font-semibold text-emerald-900/70;
+  }
+
+  .table-row {
+    @apply grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 rounded-2xl border border-emerald-100 bg-white/70 px-4 py-3 text-sm text-emerald-900;
+  }
+
+  .card-container {
+    @apply rounded-3xl border border-emerald-100 bg-white/80 p-8 shadow-lg shadow-emerald-900/10 backdrop-blur;
+  }
+
+  .section-title {
+    @apply text-2xl font-semibold text-emerald-950;
+  }
+
+  .section-subtitle {
+    @apply mt-1 text-sm text-emerald-900/70;
+  }
+
+  .text-display {
+    @apply text-4xl font-bold tracking-tight sm:text-5xl;
+  }
+
+  .text-heading-lg {
+    @apply text-3xl font-semibold;
+  }
+
+  .text-heading-md {
+    @apply text-2xl font-semibold;
+  }
+
+  .text-heading-sm {
+    @apply text-xl font-semibold;
+  }
+
+  .text-heading-xs {
+    @apply text-lg font-semibold;
+  }
+
+  .text-body-lg {
+    @apply text-lg leading-relaxed;
+  }
+
+  .text-body {
+    @apply text-base leading-relaxed;
+  }
+
+  .text-body-strong {
+    @apply text-base font-semibold;
+  }
+
+  .text-body-muted {
+    @apply text-base text-emerald-900/70;
+  }
+
+  .text-body-sm {
+    @apply text-sm;
+  }
+
+  .text-body-sm-strong {
+    @apply text-sm font-semibold;
+  }
+
+  .text-eyebrow {
+    @apply text-sm font-semibold uppercase tracking-[0.2em];
+  }
+
+  .text-caption {
+    @apply text-xs font-semibold uppercase tracking-wide;
+  }
+
+  .form-label {
+    @apply text-sm font-semibold text-emerald-900/80;
+  }
+
+  .text-body-sm-muted {
+    @apply text-sm text-emerald-900/70;
+  }
+}

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -1,18 +1,31 @@
 import { Link } from "react-router-dom";
-import { primaryButtonClasses, secondaryButtonClasses } from "../styles/ui";
+import {
+  bodySmallMutedTextClasses,
+  bodySmallStrongTextClasses,
+  bodySmallTextClasses,
+  captionTextClasses,
+  displayTextClasses,
+  largeHeadingClasses,
+  leadTextClasses,
+  primaryButtonClasses,
+  secondaryButtonClasses,
+  smallHeadingClasses,
+} from "../styles/ui";
 
 function LandingPage() {
   return (
     <div className="flex w-full flex-1 flex-col gap-12 text-emerald-900">
       <section className="grid gap-10 rounded-3xl border border-emerald-100 bg-white/80 p-10 shadow-xl shadow-emerald-900/10 backdrop-blur md:grid-cols-[1.1fr_1fr]">
         <div className="space-y-6">
-          <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm shadow-emerald-900/5">
+          <div
+            className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
+          >
             🌿 Grow whole
           </div>
-          <h1 className="text-4xl font-bold tracking-tight text-emerald-950 sm:text-5xl">
+          <h1 className={`${displayTextClasses} text-emerald-950`}>
             Grow whole, not in fragments.
           </h1>
-          <p className="text-lg leading-relaxed text-emerald-900/80">
+          <p className={`${leadTextClasses} text-emerald-900/80`}>
             Aleya weaves journaling, mentorship, and gentle accountability so you can
             notice your emotions, nurture your habits, and share progress with the
             guides who support you.
@@ -76,10 +89,10 @@ function LandingPage() {
       </section>
 
       <section className="rounded-3xl bg-emerald-600 px-8 py-10 text-white shadow-xl shadow-emerald-900/20">
-        <h2 className="text-3xl font-semibold tracking-tight">
+        <h2 className={`${largeHeadingClasses} tracking-tight`}>
           Your day is a living ecosystem.
         </h2>
-        <p className="mt-4 text-lg leading-relaxed text-white/80">
+        <p className={`mt-4 ${leadTextClasses} text-white/80`}>
           Aleya keeps the ecosystem connected—so when you tend to sleep, learning,
           relationships, and creative sparks, you can see the whole tree flourish.
         </p>
@@ -91,8 +104,8 @@ function LandingPage() {
 function FeatureCard({ title, description }) {
   return (
     <article className="rounded-3xl border border-emerald-100 bg-white/70 p-6 shadow-inner shadow-emerald-900/5">
-      <h2 className="text-xl font-semibold text-emerald-900">{title}</h2>
-      <p className="mt-3 text-sm text-emerald-900/70">{description}</p>
+      <h2 className={`${smallHeadingClasses} text-emerald-900`}>{title}</h2>
+      <p className={`mt-3 ${bodySmallMutedTextClasses} text-emerald-900/70`}>{description}</p>
     </article>
   );
 }
@@ -100,10 +113,10 @@ function FeatureCard({ title, description }) {
 function TreeLayer({ title, description, className }) {
   return (
     <div className={`space-y-2 px-6 py-5 ${className}`}>
-      <span className="text-sm font-semibold uppercase tracking-wide text-white/80">
+      <span className={`${captionTextClasses} text-white/80`}>
         {title}
       </span>
-      <p className="text-sm leading-relaxed text-white/80">{description}</p>
+      <p className={`${bodySmallTextClasses} leading-relaxed text-white/80`}>{description}</p>
     </div>
   );
 }

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,18 +1,22 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
+import {
+  bodySmallMutedTextClasses,
+  bodySmallStrongTextClasses,
+  displayTextClasses,
+  eyebrowTextClasses,
+  formLabelClasses,
+  inputClasses,
+  leadTextClasses,
+  primaryButtonClasses,
+} from "../styles/ui";
 
 function LoginPage() {
   const { login, error } = useAuth();
   const navigate = useNavigate();
   const [form, setForm] = useState({ email: "", password: "" });
   const [loading, setLoading] = useState(false);
-
-  const inputClasses =
-    "mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
-
-  const buttonClasses =
-    "inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/20 transition hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60";
 
   const handleChange = (event) => {
     const { name, value } = event.target;
@@ -36,26 +40,32 @@ function LoginPage() {
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-emerald-100 px-6 py-16">
       <div className="mx-auto grid w-full max-w-5xl items-center gap-12 lg:grid-cols-[1.15fr_1fr]">
         <div className="space-y-6 text-emerald-900">
-          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm shadow-emerald-900/5">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
+          >
             🌿 Welcome back
           </span>
-          <h1 className="text-4xl font-bold tracking-tight text-emerald-950 sm:text-5xl">
+          <h1 className={`${displayTextClasses} text-emerald-950`}>
             Welcome back
           </h1>
-          <p className="text-lg leading-relaxed text-emerald-900/80">
+          <p className={`${leadTextClasses} text-emerald-900/80`}>
             Continue tending your growth journey. Sign in to pick up where you
             left off.
           </p>
           <div className="grid gap-4 rounded-3xl border border-emerald-100 bg-white/70 p-6 shadow-inner shadow-emerald-900/5 sm:grid-cols-2">
             <div className="space-y-1">
-              <p className="text-sm font-semibold text-emerald-800">Track momentum</p>
-              <p className="text-sm text-emerald-900/70">
+              <p className={`${bodySmallStrongTextClasses} text-emerald-800`}>
+                Track momentum
+              </p>
+              <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
                 Review your reflections and notice the progress you are making.
               </p>
             </div>
             <div className="space-y-1">
-              <p className="text-sm font-semibold text-emerald-800">Stay connected</p>
-              <p className="text-sm text-emerald-900/70">
+              <p className={`${bodySmallStrongTextClasses} text-emerald-800`}>
+                Stay connected
+              </p>
+              <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
                 Message mentors, respond to prompts, and nurture your practice.
               </p>
             </div>
@@ -63,15 +73,15 @@ function LoginPage() {
         </div>
         <div className="rounded-3xl border border-emerald-100 bg-white/80 p-8 shadow-2xl shadow-emerald-900/10 backdrop-blur md:p-10">
           <div className="mb-8 space-y-2 text-center">
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-600">
+            <p className={`${eyebrowTextClasses} text-emerald-600`}>
               Sign in to your account
             </p>
-            <p className="text-sm text-emerald-900/70">
+            <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
               Enter your credentials to continue exploring Aleya.
             </p>
           </div>
           <form className="space-y-5" onSubmit={handleSubmit}>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Email
               <input
                 type="email"
@@ -83,7 +93,7 @@ function LoginPage() {
                 placeholder="name@email.com"
               />
             </label>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Password
               <input
                 type="password"
@@ -101,11 +111,15 @@ function LoginPage() {
                 {error}
               </p>
             )}
-            <button type="submit" className={buttonClasses} disabled={loading}>
+            <button
+              type="submit"
+              className={`${primaryButtonClasses} w-full`}
+              disabled={loading}
+            >
               {loading ? "Signing in..." : "Sign in"}
             </button>
           </form>
-          <p className="mt-6 text-center text-sm text-emerald-900/70">
+          <p className={`mt-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}>
             New to Aleya?{" "}
             <Link
               to="/register"

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -1,17 +1,24 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
+import {
+  bodySmallMutedTextClasses,
+  bodySmallStrongTextClasses,
+  displayTextClasses,
+  eyebrowTextClasses,
+  formLabelClasses,
+  inputClasses,
+  leadTextClasses,
+  primaryButtonClasses,
+  selectClasses,
+  textareaClasses,
+  xSmallHeadingClasses,
+} from "../styles/ui";
 
 const ROLES = [
   { value: "journaler", label: "Journaler" },
   { value: "mentor", label: "Mentor" },
 ];
-
-const inputClasses =
-  "mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
-
-const buttonClasses =
-  "inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/20 transition hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60";
 
 function RegisterPage() {
   const { register, error } = useAuth();
@@ -103,23 +110,28 @@ function RegisterPage() {
           <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-600">
             <span className="text-3xl">✉️</span>
           </div>
-          <h1 className="text-4xl font-bold text-emerald-900">Check your inbox</h1>
-          <p className="mt-4 text-lg leading-relaxed text-emerald-900/80">
+          <h1 className={`${displayTextClasses} text-emerald-900`}>Check your inbox</h1>
+          <p className={`mt-4 ${leadTextClasses} text-emerald-900/80`}>
             We've sent a verification link to {submittedEmail || "your email"}.
             Follow the link to activate your account.
           </p>
           {verificationDetails?.message && (
-            <p className="mt-4 rounded-2xl border border-emerald-100 bg-emerald-50/60 px-6 py-4 text-sm font-medium text-emerald-900/80">
+            <p
+              className={`mt-4 rounded-2xl border border-emerald-100 bg-emerald-50/60 px-6 py-4 ${bodySmallStrongTextClasses} text-emerald-900/80`}
+            >
               {verificationDetails.message}
             </p>
           )}
           {expiresCopy && (
-            <p className="mt-3 text-sm text-emerald-900/70">
+            <p className={`mt-3 ${bodySmallMutedTextClasses} text-emerald-900/70`}>
               The link will expire {expiresCopy}. If it doesn't arrive within a
               few minutes, check your spam or junk folder.
             </p>
           )}
-          <Link to="/login" className={`${buttonClasses} mt-8`}>
+          <Link
+            to="/login"
+            className={`mt-8 inline-flex items-center justify-center gap-2 ${primaryButtonClasses}`}
+          >
             Return to sign in
           </Link>
         </div>
@@ -131,26 +143,32 @@ function RegisterPage() {
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-emerald-100 px-6 py-16">
       <div className="mx-auto grid w-full max-w-5xl items-center gap-12 lg:grid-cols-[1.15fr_1fr]">
         <div className="space-y-6 text-emerald-900">
-          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 text-sm font-semibold text-emerald-700 shadow-sm shadow-emerald-900/5">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
+          >
             🌱 New to Aleya
           </span>
-          <h1 className="text-4xl font-bold tracking-tight text-emerald-950 sm:text-5xl">
+          <h1 className={`${displayTextClasses} text-emerald-950`}>
             Join Aleya
           </h1>
-          <p className="text-lg leading-relaxed text-emerald-900/80">
+          <p className={`${leadTextClasses} text-emerald-900/80`}>
             Create an account to start journaling, mentor others, or steward the
             platform. Your journey toward mindful growth begins here.
           </p>
           <div className="grid gap-4 rounded-3xl border border-emerald-100 bg-white/70 p-6 shadow-inner shadow-emerald-900/5 sm:grid-cols-2">
             <div className="space-y-1">
-              <p className="text-sm font-semibold text-emerald-800">Journalers</p>
-              <p className="text-sm text-emerald-900/70">
+              <p className={`${bodySmallStrongTextClasses} text-emerald-800`}>
+                Journalers
+              </p>
+              <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
                 Reflect with guided prompts and track meaningful insights.
               </p>
             </div>
             <div className="space-y-1">
-              <p className="text-sm font-semibold text-emerald-800">Mentors</p>
-              <p className="text-sm text-emerald-900/70">
+              <p className={`${bodySmallStrongTextClasses} text-emerald-800`}>
+                Mentors
+              </p>
+              <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
                 Share your wisdom, set your availability, and support others.
               </p>
             </div>
@@ -158,15 +176,15 @@ function RegisterPage() {
         </div>
         <div className="rounded-3xl border border-emerald-100 bg-white/80 p-8 shadow-2xl shadow-emerald-900/10 backdrop-blur md:p-10">
           <div className="mb-8 space-y-2 text-center">
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-600">
+            <p className={`${eyebrowTextClasses} text-emerald-600`}>
               Create your account
             </p>
-            <p className="text-sm text-emerald-900/70">
+            <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
               Fill in the details to unlock journaling and mentoring tools.
             </p>
           </div>
           <form className="space-y-5" onSubmit={handleSubmit}>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Name
               <input
                 type="text"
@@ -178,7 +196,7 @@ function RegisterPage() {
                 placeholder="Your full name"
               />
             </label>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Email
               <input
                 type="email"
@@ -190,7 +208,7 @@ function RegisterPage() {
                 placeholder="name@email.com"
               />
             </label>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Password
               <input
                 type="password"
@@ -203,7 +221,7 @@ function RegisterPage() {
                 placeholder="Choose a secure password"
               />
             </label>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Retype password
               <input
                 type="password"
@@ -216,13 +234,13 @@ function RegisterPage() {
                 placeholder="Confirm your password"
               />
             </label>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Role
               <select
                 name="role"
                 value={form.role}
                 onChange={handleChange}
-                className={`${inputClasses} appearance-none pr-10`}
+                className={`${selectClasses} appearance-none pr-10`}
               >
                 {ROLES.map((role) => (
                   <option key={role.value} value={role.value}>
@@ -231,7 +249,7 @@ function RegisterPage() {
                 ))}
               </select>
             </label>
-            <label className="block text-sm font-semibold text-emerald-900/80">
+            <label className={`block ${formLabelClasses}`}>
               Timezone
               <input
                 type="text"
@@ -244,10 +262,10 @@ function RegisterPage() {
 
             {form.role === "mentor" && (
               <div className="space-y-4 rounded-2xl border border-emerald-100 bg-emerald-50/60 p-5">
-                <h3 className="text-lg font-semibold text-emerald-900">
+                <h3 className={`${xSmallHeadingClasses} text-emerald-900`}>
                   Mentor profile
                 </h3>
-                <label className="block text-sm font-semibold text-emerald-900/80">
+                <label className={`block ${formLabelClasses}`}>
                   Expertise
                   <input
                     type="text"
@@ -258,7 +276,7 @@ function RegisterPage() {
                     placeholder="What topics can you guide on?"
                   />
                 </label>
-                <label className="block text-sm font-semibold text-emerald-900/80">
+                <label className={`block ${formLabelClasses}`}>
                   Availability
                   <input
                     type="text"
@@ -269,14 +287,14 @@ function RegisterPage() {
                     placeholder="Share your availability"
                   />
                 </label>
-                <label className="block text-sm font-semibold text-emerald-900/80">
+                <label className={`block ${formLabelClasses}`}>
                   Bio
                   <textarea
                     name="bio"
                     rows={3}
                     value={form.mentorProfile.bio}
                     onChange={handleMentorChange}
-                    className={`${inputClasses} resize-none`}
+                    className={`${textareaClasses} resize-none`}
                     placeholder="Introduce yourself to potential journalers"
                   />
                 </label>
@@ -288,11 +306,15 @@ function RegisterPage() {
                 {localError || error}
               </p>
             )}
-            <button type="submit" className={buttonClasses} disabled={loading}>
+            <button
+              type="submit"
+              className={`${primaryButtonClasses} w-full`}
+              disabled={loading}
+            >
               {loading ? "Creating account..." : "Create account"}
             </button>
           </form>
-          <p className="mt-6 text-center text-sm text-emerald-900/70">
+          <p className={`mt-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}>
             Already have an account?{" "}
             <Link
               to="/login"

--- a/frontend/src/pages/VerifyEmailPage.js
+++ b/frontend/src/pages/VerifyEmailPage.js
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import apiClient from "../api/client";
 import {
+  bodySmallStrongTextClasses,
   infoTextClasses,
+  mediumHeadingClasses,
   primaryButtonClasses,
   secondaryButtonClasses,
 } from "../styles/ui";
@@ -49,14 +51,18 @@ function VerifyEmailPage() {
       case "pending":
         return (
           <>
-            <p className="text-sm font-semibold text-emerald-900/80">{message}</p>
+            <p className={`${bodySmallStrongTextClasses} text-emerald-900/80`}>
+              {message}
+            </p>
             <p className={infoTextClasses}>This will only take a moment.</p>
           </>
         );
       case "success":
         return (
           <>
-            <p className="text-sm font-semibold text-emerald-900/80">{message}</p>
+            <p className={`${bodySmallStrongTextClasses} text-emerald-900/80`}>
+              {message}
+            </p>
             <Link to="/login" className={`${primaryButtonClasses} w-full`}>
               Continue to sign in
             </Link>
@@ -65,7 +71,9 @@ function VerifyEmailPage() {
       case "error":
         return (
           <>
-            <p className="rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm font-semibold text-rose-600">
+            <p
+              className={`rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 ${bodySmallStrongTextClasses} text-rose-600`}
+            >
               {message}
             </p>
             <p className={infoTextClasses}>
@@ -92,7 +100,9 @@ function VerifyEmailPage() {
       default:
         return (
           <>
-            <p className="rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm font-semibold text-rose-600">
+            <p
+              className={`rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 ${bodySmallStrongTextClasses} text-rose-600`}
+            >
               {message}
             </p>
             <p className={infoTextClasses}>
@@ -119,7 +129,7 @@ function VerifyEmailPage() {
 
   return (
     <div className="mx-auto w-full max-w-xl rounded-3xl border border-emerald-100 bg-white/80 p-8 text-center shadow-2xl shadow-emerald-900/10 backdrop-blur">
-      <h1 className="text-3xl font-semibold text-emerald-900">{heading}</h1>
+      <h1 className={`${mediumHeadingClasses} text-emerald-900`}>{heading}</h1>
       <div className="mt-4 space-y-4 text-left">{renderContent()}</div>
     </div>
   );

--- a/frontend/src/styles/ui.js
+++ b/frontend/src/styles/ui.js
@@ -1,40 +1,42 @@
-export const primaryButtonClasses =
-  "inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/20 transition hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60";
+export const primaryButtonClasses = "btn-primary";
+export const secondaryButtonClasses = "btn-secondary";
+export const subtleButtonClasses = "btn-subtle";
 
-export const secondaryButtonClasses =
-  "inline-flex items-center justify-center gap-2 rounded-2xl border border-emerald-200 bg-white/70 px-6 py-3.5 text-base font-semibold text-emerald-700 shadow-sm shadow-emerald-900/10 transition hover:-translate-y-0.5 hover:border-emerald-300 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60";
+export const inputClasses = "form-input";
+export const inputCompactClasses = "form-input-compact";
+export const textareaClasses = "form-textarea";
+export const selectClasses = "form-select";
+export const selectCompactClasses = "form-select-compact";
+export const checkboxClasses = "form-checkbox";
 
-export const subtleButtonClasses =
-  "inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent px-4 py-2.5 text-sm font-semibold text-emerald-700 transition hover:-translate-y-0.5 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60";
+export const infoTextClasses = "text-info";
+export const mutedTextClasses = "text-muted";
+export const emptyStateClasses = "empty-state";
 
-export const inputClasses =
-  "mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
+export const chipBaseClasses = "chip-base";
+export const badgeBaseClasses = "badge-base";
 
-export const inputCompactClasses =
-  "w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-2.5 text-sm text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
+export const tableHeaderClasses = "table-header";
+export const tableRowClasses = "table-row";
+export const cardContainerClasses = "card-container";
+export const sectionTitleClasses = "section-title";
+export const sectionSubtitleClasses = "section-subtitle";
 
-export const textareaClasses =
-  "mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
-
-export const selectClasses =
-  "mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
-
-export const selectCompactClasses =
-  "w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-2.5 text-sm text-emerald-900 shadow-sm transition focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100";
-
-export const checkboxClasses =
-  "h-5 w-5 rounded-md border-emerald-200 text-emerald-600 focus:ring-emerald-500";
-
-export const infoTextClasses = "text-sm text-emerald-900/70";
-export const mutedTextClasses = "text-sm text-emerald-900/60";
-export const emptyStateClasses =
-  "rounded-2xl border border-emerald-100 bg-white/60 p-6 text-center text-sm font-medium text-emerald-900/70";
-
-export const chipBaseClasses =
-  "inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700";
-
-export const badgeBaseClasses =
-  "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold capitalize tracking-wide";
+export const displayTextClasses = "text-display";
+export const largeHeadingClasses = "text-heading-lg";
+export const mediumHeadingClasses = "text-heading-md";
+export const smallHeadingClasses = "text-heading-sm";
+export const xSmallHeadingClasses = "text-heading-xs";
+export const leadTextClasses = "text-body-lg";
+export const bodyTextClasses = "text-body";
+export const bodyStrongTextClasses = "text-body-strong";
+export const bodyMutedTextClasses = "text-body-muted";
+export const bodySmallTextClasses = "text-body-sm";
+export const bodySmallStrongTextClasses = "text-body-sm-strong";
+export const bodySmallMutedTextClasses = "text-body-sm-muted";
+export const eyebrowTextClasses = "text-eyebrow";
+export const captionTextClasses = "text-caption";
+export const formLabelClasses = "form-label";
 
 const moodClassMap = {
   happy: "bg-emerald-100 text-emerald-700",
@@ -78,15 +80,3 @@ export function getStatusToneClasses(status) {
       return "text-emerald-900/70";
   }
 }
-
-export const tableHeaderClasses =
-  "grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 text-sm font-semibold text-emerald-900/70";
-
-export const tableRowClasses =
-  "grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 rounded-2xl border border-emerald-100 bg-white/70 px-4 py-3 text-sm text-emerald-900";
-
-export const cardContainerClasses =
-  "rounded-3xl border border-emerald-100 bg-white/80 p-8 shadow-lg shadow-emerald-900/10 backdrop-blur";
-
-export const sectionTitleClasses = "text-2xl font-semibold text-emerald-950";
-export const sectionSubtitleClasses = "mt-1 text-sm text-emerald-900/70";


### PR DESCRIPTION
## Summary
- define shared Tailwind component classes for buttons, forms, and typography and expose them via `src/styles/ui.js`
- adopt the new design tokens across landing, auth, layout, and journal entry surfaces
- document the reusable styles in the READMEs and add frontend contributor guidance

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb2c118e2c8333be34e4945c4872ce