### PR TITLE
Replace timezone text fields with select inputs

### DIFF
--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -14,6 +14,7 @@ import {
   textareaClasses,
   xSmallHeadingClasses,
 } from "../styles/ui";
+import TIMEZONE_OPTIONS from "../utils/timezones";
 
 const ROLES = [
   { value: "journaler", label: "Journaler" },
@@ -251,13 +252,19 @@ function RegisterPage() {
             </label>
             <label className={`block ${formLabelClasses}`}>
               Timezone
-              <input
-                type="text"
+              <select
                 name="timezone"
                 value={form.timezone}
                 onChange={handleChange}
-                className={inputClasses}
-              />
+                className={`${selectClasses} appearance-none pr-10`}
+              >
+                <option value="">Select your timezone</option>
+                {TIMEZONE_OPTIONS.map((timezone) => (
+                  <option key={timezone} value={timezone}>
+                    {timezone}
+                  </option>
+                ))}
+              </select>
             </label>
 
             {form.role === "mentor" && (

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -10,6 +10,7 @@ import {
   selectClasses,
   textareaClasses,
 } from "../styles/ui";
+import TIMEZONE_OPTIONS from "../utils/timezones";
 
 function SettingsPage() {
   const { user, token, updateProfile } = useAuth();
@@ -152,13 +153,19 @@ function SettingsPage() {
           </label>
           <label className="block text-sm font-semibold text-emerald-900/80">
             Timezone
-            <input
-              type="text"
+            <select
               name="timezone"
-              className={inputClasses}
+              className={`${selectClasses} appearance-none pr-10`}
               value={form.timezone}
               onChange={handleChange}
-            />
+            >
+              <option value="">Select your timezone</option>
+              {TIMEZONE_OPTIONS.map((timezone) => (
+                <option key={timezone} value={timezone}>
+                  {timezone}
+                </option>
+              ))}
+            </select>
           </label>
           <label className="block text-sm font-semibold text-emerald-900/80">
             New password

--- a/frontend/src/utils/timezones.js
+++ b/frontend/src/utils/timezones.js
@@ -1,0 +1,47 @@
+const FALLBACK_TIMEZONES = [
+  "UTC",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "Africa/Nairobi",
+  "America/Argentina/Buenos_Aires",
+  "America/Bogota",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Mexico_City",
+  "America/New_York",
+  "America/Santiago",
+  "America/Sao_Paulo",
+  "Asia/Bangkok",
+  "Asia/Dubai",
+  "Asia/Hong_Kong",
+  "Asia/Jakarta",
+  "Asia/Kolkata",
+  "Asia/Seoul",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Brisbane",
+  "Australia/Melbourne",
+  "Australia/Sydney",
+  "Europe/Amsterdam",
+  "Europe/Berlin",
+  "Europe/Istanbul",
+  "Europe/Lisbon",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Paris",
+  "Europe/Prague",
+  "Europe/Rome",
+  "Europe/Stockholm",
+  "Europe/Warsaw",
+  "Pacific/Auckland",
+];
+
+export const TIMEZONE_OPTIONS =
+  typeof Intl !== "undefined" && typeof Intl.supportedValuesOf === "function"
+    ? Intl.supportedValuesOf("timeZone")
+    : FALLBACK_TIMEZONES;
+
+export default TIMEZONE_OPTIONS;


### PR DESCRIPTION
## Summary
- replace free-text timezone inputs on the registration and settings forms with select controls backed by a shared timezone list
- add a reusable timezone options helper that prefers Intl.supportedValuesOf with a curated fallback set

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb2f81d6208333bf6f5f5dcb414beb