### PR TITLE
Improve mobile navigation layout

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import {
@@ -8,6 +9,7 @@ import {
   primaryButtonClasses,
   secondaryButtonClasses,
   subtleButtonClasses,
+  iconButtonClasses,
 } from "../styles/ui";
 
 const roleNavigation = {
@@ -36,75 +38,190 @@ function Layout({ children }) {
   const navigate = useNavigate();
 
   const links = user ? roleNavigation[user.role] || [] : [];
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const handleLogout = () => {
     logout();
     navigate("/");
   };
 
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen((prev) => !prev);
+  };
+
+  const closeMobileMenu = () => {
+    setIsMobileMenuOpen(false);
+  };
+
+  const AuthControls = ({ orientation = "horizontal", onNavigate }) => {
+    if (user) {
+      const containerClasses =
+        orientation === "vertical"
+          ? "flex flex-col gap-3"
+          : "flex items-center gap-4";
+      const textAlignment = orientation === "vertical" ? "text-left" : "text-right";
+      const buttonClasses =
+        orientation === "vertical"
+          ? `${secondaryButtonClasses} w-full px-5 py-2.5 text-sm`
+          : `${secondaryButtonClasses} px-5 py-2.5 text-sm`;
+
+      const handleLogoutClick = () => {
+        handleLogout();
+        if (orientation === "vertical") {
+          onNavigate?.();
+        }
+      };
+
+      return (
+        <div className={containerClasses}>
+          <div className={textAlignment}>
+            <span className={`block ${bodySmallStrongTextClasses} text-emerald-900`}>
+              {user.name}
+            </span>
+            <span className={`${captionTextClasses} text-emerald-900/60`}>{user.role}</span>
+          </div>
+          <button type="button" className={buttonClasses} onClick={handleLogoutClick}>
+            Log out
+          </button>
+        </div>
+      );
+    }
+
+    const containerClasses =
+      orientation === "vertical"
+        ? "flex flex-col gap-3"
+        : "flex flex-wrap items-center gap-3";
+
+    const signInClasses =
+      orientation === "vertical"
+        ? `${subtleButtonClasses} w-full justify-center px-4 py-2`
+        : `${subtleButtonClasses} px-4 py-2`;
+
+    const joinClasses =
+      orientation === "vertical"
+        ? `${primaryButtonClasses} w-full justify-center px-5 py-2.5 text-sm`
+        : `${primaryButtonClasses} px-5 py-2.5 text-sm`;
+
+    const handleNavigate = () => {
+      if (orientation === "vertical") {
+        onNavigate?.();
+      }
+    };
+
+    return (
+      <div className={containerClasses}>
+        <NavLink to="/login" className={signInClasses} onClick={handleNavigate}>
+          Sign in
+        </NavLink>
+        <NavLink to="/register" className={joinClasses} onClick={handleNavigate}>
+          Join Aleya
+        </NavLink>
+      </div>
+    );
+  };
+
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-br from-emerald-50 via-white to-emerald-100 text-emerald-950">
       <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/80 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
-          <button
-            type="button"
-            className={`rounded-full border border-transparent bg-transparent leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${largeHeadingClasses}`}
-            onClick={() => navigate(user ? "/dashboard" : "/")}
-          >
-            Aleya
-          </button>
-          <nav
-            className={`flex flex-1 flex-wrap items-center justify-center gap-2 ${bodySmallStrongTextClasses} text-emerald-900/70`}
-          >
-            {links.map((link) => (
-              <NavLink
-                key={link.to}
-                to={link.to}
-                className={({ isActive }) =>
-                  `rounded-full px-4 py-2 transition ${
-                    isActive
-                      ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
-                      : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
-                  }`
-                }
-              >
-                {link.label}
-              </NavLink>
-            ))}
-          </nav>
+        <div className="mx-auto w-full max-w-6xl px-6 py-4">
           <div className="flex items-center gap-4">
-            {user ? (
-              <>
-                <div className="text-right">
-                  <span className={`block ${bodySmallStrongTextClasses} text-emerald-900`}>
-                    {user.name}
-                  </span>
-                  <span className={`${captionTextClasses} text-emerald-900/60`}>
-                    {user.role}
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
-                  onClick={handleLogout}
-                >
-                  Log out
-                </button>
-              </>
-            ) : (
-              <div className="flex flex-wrap items-center gap-3">
-                <NavLink to="/login" className={`${subtleButtonClasses} px-4 py-2`}>
-                  Sign in
-                </NavLink>
+            <button
+              type="button"
+              className={`rounded-full border border-transparent bg-transparent leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${largeHeadingClasses}`}
+              onClick={() => navigate(user ? "/dashboard" : "/")}
+            >
+              Aleya
+            </button>
+            <nav
+              className={`hidden flex-1 items-center justify-center gap-2 md:flex ${bodySmallStrongTextClasses} text-emerald-900/70`}
+            >
+              {links.map((link) => (
                 <NavLink
-                  to="/register"
-                  className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
+                  key={link.to}
+                  to={link.to}
+                  className={({ isActive }) =>
+                    `rounded-full px-4 py-2 transition ${
+                      isActive
+                        ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
+                        : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
+                    }`
+                  }
                 >
-                  Join Aleya
+                  {link.label}
                 </NavLink>
-              </div>
-            )}
+              ))}
+            </nav>
+            <div className="hidden md:block">
+              <AuthControls />
+            </div>
+            <div className="ml-auto flex items-center gap-3 md:hidden">
+              <button
+                type="button"
+                className={`${iconButtonClasses} ${
+                  isMobileMenuOpen ? "bg-emerald-600 text-white hover:text-white" : ""
+                }`}
+                onClick={toggleMobileMenu}
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="mobile-navigation"
+              >
+                <span className="sr-only">
+                  {isMobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+                </span>
+                {isMobileMenuOpen ? (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    className="h-5 w-5"
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                  </svg>
+                ) : (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    className="h-5 w-5"
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
+          {isMobileMenuOpen && (
+            <div className="mt-4 flex flex-col gap-4 md:hidden" id="mobile-navigation">
+              {links.length > 0 && (
+                <nav
+                  className={`flex flex-col gap-2 ${bodySmallStrongTextClasses} text-emerald-900/80`}
+                >
+                  {links.map((link) => (
+                    <NavLink
+                      key={link.to}
+                      to={link.to}
+                      className={({ isActive }) =>
+                        `rounded-full px-4 py-2 transition ${
+                          isActive
+                            ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
+                            : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
+                        }`
+                      }
+                      onClick={closeMobileMenu}
+                    >
+                      {link.label}
+                    </NavLink>
+                  ))}
+                </nav>
+              )}
+              <AuthControls orientation="vertical" onNavigate={closeMobileMenu} />
+            </div>
+          )}
         </div>
       </header>
       <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-12">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,10 @@
     @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent px-4 py-2.5 text-sm font-semibold text-emerald-700 transition hover:-translate-y-0.5 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
   }
 
+  .icon-button {
+    @apply inline-flex h-11 w-11 items-center justify-center rounded-full border border-emerald-200 bg-white/80 text-emerald-700 shadow-sm shadow-emerald-900/10 transition hover:border-emerald-300 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600;
+  }
+
   .form-input {
     @apply mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
   }

--- a/frontend/src/styles/ui.js
+++ b/frontend/src/styles/ui.js
@@ -1,6 +1,7 @@
 export const primaryButtonClasses = "btn-primary";
 export const secondaryButtonClasses = "btn-secondary";
 export const subtleButtonClasses = "btn-subtle";
+export const iconButtonClasses = "icon-button";
 
 export const inputClasses = "form-input";
 export const inputCompactClasses = "form-input-compact";


### PR DESCRIPTION
## Summary
- add a reusable icon button style token for navigation controls
- rework the header layout to show a hamburger toggle and collapsible nav on mobile
- ensure authentication controls render within the mobile panel and close the menu on navigation

## Testing
- npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb310c4f448333951f5e866c669382