### PR TITLE
Remove duplicate dashboard reflection header

### DIFF
--- a/frontend/src/components/SectionCard.js
+++ b/frontend/src/components/SectionCard.js
@@ -5,19 +5,32 @@ import {
 } from "../styles/ui";
 
 function SectionCard({ title, subtitle, action, children, icon }) {
+  const showHeaderText = Boolean(title || subtitle || icon);
+  const showHeader = showHeaderText || Boolean(action);
+
   return (
-    <section className={`${cardContainerClasses} w-full`}> 
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="space-y-1">
-          <h2 className={sectionTitleClasses}>
-            {icon && <span className="mr-2 inline-flex items-center">{icon}</span>}
-            {title}
-          </h2>
-          {subtitle && <p className={sectionSubtitleClasses}>{subtitle}</p>}
+    <section className={`${cardContainerClasses} w-full`}>
+      {showHeader && (
+        <div
+          className={`flex flex-wrap items-center gap-4 ${
+            showHeaderText ? "justify-between" : "justify-end"
+          }`}
+        >
+          {showHeaderText && (
+            <div className="space-y-1">
+              <h2 className={sectionTitleClasses}>
+                {icon && (
+                  <span className="mr-2 inline-flex items-center">{icon}</span>
+                )}
+                {title}
+              </h2>
+              {subtitle && <p className={sectionSubtitleClasses}>{subtitle}</p>}
+            </div>
+          )}
+          {action && <div className="flex items-center gap-3">{action}</div>}
         </div>
-        {action && <div className="flex items-center gap-3">{action}</div>}
-      </div>
-      <div className="mt-6 space-y-4">{children}</div>
+      )}
+      <div className={`${showHeader ? "mt-6" : ""} space-y-4`}>{children}</div>
     </section>
   );
 }

--- a/frontend/src/pages/JournalerDashboard.js
+++ b/frontend/src/pages/JournalerDashboard.js
@@ -205,8 +205,6 @@ function JournalerDashboard() {
 
       <div className="grid gap-6 lg:grid-cols-2">
         <SectionCard
-          title="Daily reflection"
-          subtitle="Root yourself with the default Aleya prompt or a mentor form"
           action={
             forms.length > 1 && (
               <select


### PR DESCRIPTION
## Summary
- allow SectionCard to omit its title/subtitle while keeping any header actions aligned
- remove the redundant "Daily reflection" heading so the form's "Daily Roots Check-In" prompt stands on its own

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb3d1a78708333a3cf913fb763fe79