### PR TITLE
Add mentor profile dialog to mentorship page

### DIFF
--- a/frontend/src/components/MentorProfileDialog.js
+++ b/frontend/src/components/MentorProfileDialog.js
@@ -1,0 +1,96 @@
+import {
+  bodyTextClasses,
+  bodySmallMutedTextClasses,
+  mediumHeadingClasses,
+  primaryButtonClasses,
+  secondaryButtonClasses,
+} from "../styles/ui";
+
+function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
+  if (!mentor) return null;
+
+  const handleRequest = () => {
+    if (typeof onRequest === "function") {
+      onRequest(mentor);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-emerald-950/40 px-4 py-10"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mentor-profile-heading"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl sm:p-8"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h2
+              id="mentor-profile-heading"
+              className={`${mediumHeadingClasses} text-emerald-900`}
+            >
+              {mentor.name}
+            </h2>
+            {mentor.expertise && (
+              <p className={bodySmallMutedTextClasses}>{mentor.expertise}</p>
+            )}
+            {mentor.email && (
+              <p className={bodySmallMutedTextClasses}>{mentor.email}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className={`${secondaryButtonClasses} px-4 py-2 text-sm`}
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-6 space-y-4">
+          {mentor.availability && (
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-800/70">
+                Availability
+              </h3>
+              <p className={bodyTextClasses}>{mentor.availability}</p>
+            </div>
+          )}
+
+          {mentor.bio && (
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-800/70">
+                About
+              </h3>
+              <p className={`${bodyTextClasses} whitespace-pre-line`}>{mentor.bio}</p>
+            </div>
+          )}
+
+          {!mentor.availability && !mentor.bio && (
+            <p className={bodySmallMutedTextClasses}>
+              This mentor hasn&apos;t shared a detailed profile yet.
+            </p>
+          )}
+        </div>
+
+        {canRequest && (
+          <div className="mt-8 flex flex-wrap justify-end gap-3">
+            <button
+              type="button"
+              className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
+              onClick={handleRequest}
+            >
+              Request mentorship
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MentorProfileDialog;

--- a/frontend/src/pages/MentorConnectionsPage.js
+++ b/frontend/src/pages/MentorConnectionsPage.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import apiClient from "../api/client";
 import LoadingState from "../components/LoadingState";
 import MentorRequestList from "../components/MentorRequestList";
+import MentorProfileDialog from "../components/MentorProfileDialog";
 import SectionCard from "../components/SectionCard";
 import { useAuth } from "../context/AuthContext";
 import {
@@ -23,6 +24,7 @@ function MentorConnectionsPage() {
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState(null);
+  const [selectedMentor, setSelectedMentor] = useState(null);
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -86,6 +88,7 @@ function MentorConnectionsPage() {
       token
     );
     setMessage(`Request sent to ${mentor.name}.`);
+    setSelectedMentor(null);
     load();
   };
 
@@ -152,12 +155,16 @@ function MentorConnectionsPage() {
                       key={mentor.id}
                       className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-100 bg-white/70 p-5"
                     >
-                      <div className="space-y-1">
-                        <p className="text-base font-semibold text-emerald-900">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedMentor(mentor)}
+                        className="group flex-1 space-y-1 text-left"
+                      >
+                        <p className="text-base font-semibold text-emerald-900 group-hover:text-emerald-700">
                           {mentor.name}
                         </p>
                         <p className={infoTextClasses}>{mentor.expertise || "Mentor"}</p>
-                      </div>
+                      </button>
                       <button
                         type="button"
                         className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
@@ -240,6 +247,12 @@ function MentorConnectionsPage() {
           )}
         </SectionCard>
       )}
+      <MentorProfileDialog
+        mentor={selectedMentor}
+        onClose={() => setSelectedMentor(null)}
+        onRequest={sendRequest}
+        canRequest={canRequestMentor}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show a mentor profile dialog from the mentorship page when a journaler selects a mentor
- allow journalers to request mentorship directly from the profile dialog while keeping the existing quick action

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb40ba70808333af45684475161c8f