### PR TITLE
Add email update option to settings page

### DIFF
--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -17,6 +17,7 @@ function SettingsPage() {
   const { user, token, updateProfile, deleteAccount } = useAuth();
   const [form, setForm] = useState({
     name: "",
+    email: "",
     timezone: "",
     remindersDaily: false,
     remindersWeekly: true,
@@ -36,6 +37,7 @@ function SettingsPage() {
     if (!user) return;
     setForm({
       name: user.name,
+      email: user.email,
       timezone: user.timezone,
       remindersDaily: user.notificationPreferences?.reminders?.daily ?? false,
       remindersWeekly: user.notificationPreferences?.reminders?.weekly ?? true,
@@ -100,6 +102,7 @@ function SettingsPage() {
     event.preventDefault();
     const payload = {
       name: form.name,
+      email: form.email,
       timezone: form.timezone,
       notificationPreferences: {
         reminders: {
@@ -186,6 +189,16 @@ function SettingsPage() {
               name="name"
               className={inputClasses}
               value={form.name}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="block text-sm font-semibold text-emerald-900/80">
+            Email address
+            <input
+              type="email"
+              name="email"
+              className={inputClasses}
+              value={form.email}
               onChange={handleChange}
             />
           </label>


### PR DESCRIPTION
## Summary
- allow the settings form to edit the signed-in user's email address alongside their name
- prefill the settings form with the current email value and include it in profile updates

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb469cdd9c8333a28b0e85dd276fc0