### PR TITLE
Implement app-wide notifications and email triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ tail -f backend/logs/aleya.log
 
 If you customise `LOG_FILE` in `.env`, the logger will create the directory automatically. Log rotation is controlled by `LOG_MAX_SIZE` (bytes) and `LOG_MAX_FILES`.
 
+## Notification system
+
+Aleya pairs in-app notifications with transactional emails so mentors never miss important activity.
+
+- **Global bell:** Mentors see a bell icon in the navigation bar. Clicking it opens a panel with the five most recent mentee updates and a shortcut back to the dashboard. The same feed appears on the mentor dashboard and mentorship pages so updates are always within reach.
+- **Respect sharing choices:** Notification payloads only include the information a journaler agreed to share (mood, summary, or full form responses). Mentor notification preferences further limit the detail that appears in email digests.
+- **Email triggers:** The backend sends emails for account verification, when a mentorship link is confirmed, and whenever a journaler submits either the default check-in or an assigned form. Emails go to the linked mentor(s) and reuse the same privacy filtering logic as the in-app feed.
+- **Configuration:** Set the SMTP variables described in [Configure environment variables](#1-configure-environment-variables). The server validates the credentials on boot, so you'll see a descriptive error if anything is missing.
+- **Testing locally:** With SMTP credentials in place, submit a journal entry that is shared beyond "Private" to generate both the in-app badge and mentor email. Marking a notification as read immediately updates the unread badge count across the interface.
+
 ## 5. Running with Docker (optional)
 
 You can develop with Docker once your database is reachable from the containers (for a locally running Postgres instance on macOS/Windows use `host.docker.internal` in `DATABASE_URL`).

--- a/backend/utils/entries.js
+++ b/backend/utils/entries.js
@@ -1,0 +1,77 @@
+const LEVELS = ["private", "mood", "summary", "full"];
+
+function normalizeLevel(level) {
+  if (!level) return "private";
+  const normalized = level.toString().toLowerCase();
+  return LEVELS.includes(normalized) ? normalized : "private";
+}
+
+function resolveSharedLevel(entryLevel, maxLevel) {
+  const normalizedEntry = normalizeLevel(entryLevel);
+  if (!maxLevel) {
+    return normalizedEntry;
+  }
+
+  const normalizedMax = normalizeLevel(maxLevel);
+  const entryIndex = LEVELS.indexOf(normalizedEntry);
+  const maxIndex = LEVELS.indexOf(normalizedMax);
+
+  if (entryIndex === -1) {
+    return "private";
+  }
+
+  if (maxIndex === -1) {
+    return normalizedEntry;
+  }
+
+  return LEVELS[Math.min(entryIndex, maxIndex)];
+}
+
+function shapeEntryForMentor(entry, options = {}) {
+  if (!entry) {
+    return null;
+  }
+
+  const { maxLevel } = options;
+  const sharedLevel = resolveSharedLevel(entry.sharedLevel, maxLevel);
+
+  const shaped = {
+    id: entry.id,
+    formId: entry.formId,
+    entryDate: entry.entryDate,
+    mood: entry.mood,
+    sharedLevel,
+    summary: null,
+    responses: [],
+    formTitle: entry.formTitle,
+  };
+
+  if (sharedLevel === "private") {
+    shaped.mood = null;
+    return shaped;
+  }
+
+  if (sharedLevel === "mood") {
+    return shaped;
+  }
+
+  if (sharedLevel === "summary") {
+    shaped.summary = entry.summary || null;
+    return shaped;
+  }
+
+  if (sharedLevel === "full") {
+    shaped.summary = entry.summary || null;
+    shaped.responses = Array.isArray(entry.responses)
+      ? entry.responses
+      : [];
+    return shaped;
+  }
+
+  return shaped;
+}
+
+module.exports = {
+  shapeEntryForMentor,
+  resolveSharedLevel,
+};

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -1,0 +1,38 @@
+const nodemailer = require("nodemailer");
+const { logger } = require("./logger");
+
+function getMailTransporter(app) {
+  if (!app?.locals?.mailSettings) {
+    throw new Error("Mail settings are not configured");
+  }
+
+  if (!app.locals.mailTransporter) {
+    app.locals.mailTransporter = nodemailer.createTransport(
+      app.locals.mailSettings
+    );
+  }
+
+  return app.locals.mailTransporter;
+}
+
+async function sendEmail(app, message, context = {}) {
+  const transporter = getMailTransporter(app);
+
+  try {
+    await transporter.sendMail({
+      from: app.locals.mailSettings.from,
+      ...message,
+    });
+  } catch (error) {
+    logger.error("Failed to send email", {
+      error: error.message,
+      context,
+    });
+    throw error;
+  }
+}
+
+module.exports = {
+  getMailTransporter,
+  sendEmail,
+};

--- a/backend/utils/notifications.js
+++ b/backend/utils/notifications.js
@@ -1,0 +1,197 @@
+const { sendEmail } = require("./mailer");
+const { shapeEntryForMentor } = require("./entries");
+const { logger } = require("./logger");
+
+function parsePreferences(preferences) {
+  if (!preferences) {
+    return {};
+  }
+
+  if (typeof preferences === "object") {
+    return preferences;
+  }
+
+  try {
+    return JSON.parse(preferences);
+  } catch (error) {
+    return {};
+  }
+}
+
+function resolveFrontendBaseUrl() {
+  return (
+    process.env.APP_BASE_URL ||
+    process.env.FRONTEND_URL ||
+    (process.env.CORS_ORIGIN
+      ? process.env.CORS_ORIGIN.split(",")[0].trim()
+      : null) ||
+    "http://localhost:3000"
+  );
+}
+
+function buildFrontendLink(pathname = "/dashboard") {
+  try {
+    const baseUrl = new URL(resolveFrontendBaseUrl());
+    const trimmedPath = baseUrl.pathname.replace(/\/$/, "");
+    baseUrl.pathname = `${trimmedPath}${pathname.startsWith("/") ? "" : "/"}${
+      pathname.startsWith("/") ? pathname.slice(1) : pathname
+    }`;
+    return baseUrl.toString();
+  } catch (error) {
+    return `http://localhost:3000${pathname}`;
+  }
+}
+
+function formatResponsesForText(responses) {
+  return responses
+    .filter((response) =>
+      response && response.value !== null && response.value !== ""
+    )
+    .map((response) => `- ${response.label}: ${response.value}`)
+    .join("\n");
+}
+
+function formatResponsesForHtml(responses) {
+  const items = responses.filter(
+    (response) => response && response.value !== null && response.value !== ""
+  );
+
+  if (!items.length) {
+    return "";
+  }
+
+  const listItems = items
+    .map(
+      (response) =>
+        `<li><strong>${response.label}:</strong> ${String(response.value)}</li>`
+    )
+    .join("");
+
+  return `<ul style="padding-left:20px;margin:12px 0;">${listItems}</ul>`;
+}
+
+async function safeSend(app, message, context) {
+  if (!message?.to) {
+    return;
+  }
+
+  try {
+    await sendEmail(app, message, context);
+  } catch (error) {
+    logger.warn("Email dispatch failed", {
+      error: error.message,
+      context,
+    });
+  }
+}
+
+async function sendMentorLinkEmails(app, { mentor, journaler }) {
+  const dashboardUrl = buildFrontendLink("/mentorship");
+
+  const mentorMessage = {
+    to: mentor.email,
+    subject: `${journaler.name} confirmed your mentorship on Aleya`,
+    text: `Hi ${mentor.name || "there"},\n\n${
+      journaler.name
+    } confirmed your mentorship request.\n\nVisit ${dashboardUrl} to review their reflections and share your guidance.\n\nRooted in care,\nThe Aleya team`,
+    html: `<p>Hi ${mentor.name || "there"},</p>` +
+      `<p><strong>${journaler.name}</strong> confirmed your mentorship request.</p>` +
+      `<p><a href="${dashboardUrl}" style="display:inline-block;padding:12px 20px;background:#2f855a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">Open mentorship</a></p>` +
+      `<p>Rooted in care,<br/>The Aleya team</p>`,
+  };
+
+  const journalerMessage = {
+    to: journaler.email,
+    subject: `You're now connected with ${mentor.name} on Aleya`,
+    text: `Hi ${journaler.name || "there"},\n\n${
+      mentor.name
+    } is now officially linked as your mentor on Aleya.\n\nVisit ${dashboardUrl} to manage the connection or share your next reflection.\n\nRooted in care,\nThe Aleya team`,
+    html: `<p>Hi ${journaler.name || "there"},</p>` +
+      `<p>You're now officially linked with <strong>${mentor.name}</strong> on Aleya.</p>` +
+      `<p><a href="${dashboardUrl}" style="display:inline-block;padding:12px 20px;background:#2f855a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">View mentorship</a></p>` +
+      `<p>Rooted in care,<br/>The Aleya team</p>`,
+  };
+
+  await Promise.all([
+    safeSend(app, mentorMessage, {
+      type: "mentor-link-mentor",
+      mentorId: mentor.id,
+      journalerId: journaler.id,
+    }),
+    safeSend(app, journalerMessage, {
+      type: "mentor-link-journaler",
+      mentorId: mentor.id,
+      journalerId: journaler.id,
+    }),
+  ]);
+}
+
+async function sendMentorEntryEmail(app, { mentor, journaler, entry }) {
+  if (!mentor?.email || !entry) {
+    return;
+  }
+
+  const preferences = parsePreferences(mentor.notification_preferences);
+  const maxLevel = preferences.mentorNotifications || "summary";
+  const shaped = shapeEntryForMentor(entry, { maxLevel });
+
+  if (!shaped || shaped.sharedLevel === "private") {
+    return;
+  }
+
+  const dashboardUrl = buildFrontendLink("/dashboard");
+  const entryDateText = entry.entryDate
+    ? ` on ${entry.entryDate}`
+    : "";
+  const subject = `${journaler.name} shared a ${
+    entry.formTitle || "journal entry"
+  }${entryDateText}`;
+
+  const summaryText = shaped.summary
+    ? `\nSummary: ${shaped.summary}`
+    : "";
+  const responsesText = shaped.responses.length
+    ? `\n\nShared responses:\n${formatResponsesForText(shaped.responses)}`
+    : "";
+
+  const text = `Hi ${mentor.name || "there"},\n\n${journaler.name} shared a new ${
+    entry.formTitle || "journal entry"
+  }${entryDateText}.\nMood: ${shaped.mood || "Not provided"}${summaryText}${responsesText}\n\nSign in to support them: ${dashboardUrl}\n\nRooted in care,\nThe Aleya team`;
+
+  const htmlSummary = shaped.summary
+    ? `<p><strong>Summary:</strong> ${shaped.summary}</p>`
+    : "";
+  const htmlResponses = formatResponsesForHtml(shaped.responses);
+
+  const html = `<p>Hi ${mentor.name || "there"},</p>` +
+    `<p><strong>${journaler.name}</strong> shared a new <em>${
+      entry.formTitle || "journal entry"
+    }</em>${entryDateText}.</p>` +
+    `<p><strong>Mood:</strong> ${shaped.mood || "Not provided"}</p>` +
+    htmlSummary +
+    htmlResponses +
+    `<p><a href="${dashboardUrl}" style="display:inline-block;padding:12px 20px;background:#2f855a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">Review on Aleya</a></p>` +
+    `<p>Rooted in care,<br/>The Aleya team</p>`;
+
+  await safeSend(
+    app,
+    {
+      to: mentor.email,
+      subject,
+      text,
+      html,
+    },
+    {
+      type: "mentor-entry",
+      mentorId: mentor.id,
+      journalerId: journaler.id,
+      entryId: entry.id,
+      sharedLevel: shaped.sharedLevel,
+    }
+  );
+}
+
+module.exports = {
+  sendMentorLinkEmails,
+  sendMentorEntryEmail,
+};

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 import Layout from "./components/Layout";
 import { AuthProvider, useAuth } from "./context/AuthContext";
+import { NotificationProvider } from "./context/NotificationContext";
 import LandingPage from "./pages/LandingPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
@@ -50,8 +51,9 @@ function AppRoutes() {
   const { user } = useAuth();
 
   return (
-    <Layout>
-      <Routes>
+    <NotificationProvider>
+      <Layout>
+        <Routes>
         <Route
           path="/"
           element={user ? <Navigate to="/dashboard" replace /> : <LandingPage />}
@@ -106,8 +108,9 @@ function AppRoutes() {
           }
         />
         <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </Layout>
+        </Routes>
+      </Layout>
+    </NotificationProvider>
   );
 }
 

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
+import NotificationBell from "./NotificationBell";
 import {
   bodySmallMutedTextClasses,
   bodySmallStrongTextClasses,
@@ -151,10 +152,12 @@ function Layout({ children }) {
                 </NavLink>
               ))}
             </nav>
-            <div className="hidden md:block">
+            <div className="hidden items-center gap-3 md:flex">
+              <NotificationBell />
               <AuthControls />
             </div>
             <div className="ml-auto flex items-center gap-3 md:hidden">
+              <NotificationBell />
               <button
                 type="button"
                 className={`${iconButtonClasses} ${

--- a/frontend/src/components/LoadingState.js
+++ b/frontend/src/components/LoadingState.js
@@ -1,9 +1,9 @@
-function LoadingState({ label = "Loading" }) {
-  return (
-    <div className="flex min-h-[40vh] items-center justify-center text-sm font-medium text-emerald-900/70">
-      {label}…
-    </div>
-  );
+function LoadingState({ label = "Loading", compact = false }) {
+  const containerClasses = compact
+    ? "flex items-center justify-center text-sm font-medium text-emerald-900/70"
+    : "flex min-h-[40vh] items-center justify-center text-sm font-medium text-emerald-900/70";
+
+  return <div className={containerClasses}>{label}…</div>;
 }
 
 export default LoadingState;

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import NotificationList from "./NotificationList";
+import { useNotifications } from "../context/NotificationContext";
+import {
+  bodySmallMutedTextClasses,
+  iconButtonClasses,
+} from "../styles/ui";
+
+function NotificationBell() {
+  const {
+    notifications,
+    unreadCount,
+    loading,
+    refresh,
+    markAsRead,
+    isEnabled,
+  } = useNotifications();
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef(null);
+  const panelRef = useRef(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    refresh();
+
+    const handleClick = (event) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen, refresh]);
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  const toggleOpen = () => {
+    setIsOpen((previous) => !previous);
+  };
+
+  const handleMarkRead = async (notificationId) => {
+    await markAsRead(notificationId);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`${iconButtonClasses} relative`}
+        onClick={toggleOpen}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+      >
+        <span className="sr-only">
+          {isOpen ? "Close notifications" : "Open notifications"}
+        </span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="h-5 w-5"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0 1 18 14.158V11a6 6 0 1 0-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 1 1-6 0v-1m6 0H9"
+          />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-rose-500 px-[6px] text-[10px] font-semibold text-white">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          ref={panelRef}
+          className="absolute right-0 z-40 mt-3 w-80 max-w-sm rounded-2xl border border-emerald-100 bg-white/95 p-4 shadow-xl"
+        >
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-sm font-semibold text-emerald-900">
+              Notifications
+            </p>
+            <button
+              type="button"
+              className="text-xs font-semibold text-emerald-600 hover:text-emerald-700"
+              onClick={() => {
+                setIsOpen(false);
+                navigate("/dashboard");
+              }}
+            >
+              View dashboard
+            </button>
+          </div>
+          <NotificationList
+            notifications={notifications}
+            onMarkRead={handleMarkRead}
+            loading={loading}
+            limit={5}
+          />
+          <p className={`${bodySmallMutedTextClasses} mt-3 text-emerald-900/70`}>
+            New entries appear here when mentees share reflections with you.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NotificationBell;

--- a/frontend/src/components/NotificationList.js
+++ b/frontend/src/components/NotificationList.js
@@ -1,0 +1,97 @@
+import { format, parseISO } from "date-fns";
+import LoadingState from "./LoadingState";
+import {
+  bodySmallMutedTextClasses,
+  emptyStateClasses,
+  infoTextClasses,
+  secondaryButtonClasses,
+} from "../styles/ui";
+
+function formatEntryDate(value) {
+  if (!value) return null;
+  try {
+    return format(parseISO(value), "MMM d, yyyy");
+  } catch (error) {
+    return value;
+  }
+}
+
+function formatCreatedAt(value) {
+  if (!value) return null;
+  try {
+    return format(parseISO(value), "MMM d, yyyy p");
+  } catch (error) {
+    return value;
+  }
+}
+
+function NotificationList({
+  notifications,
+  onMarkRead,
+  loading = false,
+  emptyLabel = "You're all caught up.",
+  limit,
+}) {
+  if (loading) {
+    return <LoadingState label="Loading notifications" compact />;
+  }
+
+  const visibleNotifications = Array.isArray(notifications)
+    ? notifications.slice(0, limit || notifications.length)
+    : [];
+
+  if (!visibleNotifications.length) {
+    return <p className={emptyStateClasses}>{emptyLabel}</p>;
+  }
+
+  return (
+    <ul className="grid gap-4">
+      {visibleNotifications.map((notification) => {
+        const entryDate = formatEntryDate(notification.entry?.entryDate);
+        const createdAt = formatCreatedAt(notification.createdAt);
+        const mood = notification.entry?.mood;
+        const summary = notification.entry?.summary;
+
+        return (
+          <li
+            key={notification.id}
+            className="flex flex-wrap items-start justify-between gap-4 rounded-2xl border border-emerald-100 bg-white/70 p-5"
+          >
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <p className="text-base font-semibold text-emerald-900">
+                  {notification.journaler?.name || "Mentee update"}
+                </p>
+                <p className={infoTextClasses}>
+                  {entryDate ? `${entryDate} · ` : ""}
+                  Mood: {mood || "—"}
+                </p>
+                {summary && (
+                  <p className={`${bodySmallMutedTextClasses} text-emerald-900/80`}>
+                    {summary}
+                  </p>
+                )}
+              </div>
+              {createdAt && (
+                <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
+                  Shared {createdAt}
+                </p>
+              )}
+            </div>
+            {!notification.readAt && (
+              <button
+                type="button"
+                className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                onClick={() => onMarkRead?.(notification.id)}
+              >
+                Mark as read
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default NotificationList;

--- a/frontend/src/context/NotificationContext.js
+++ b/frontend/src/context/NotificationContext.js
@@ -1,0 +1,103 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import apiClient from "../api/client";
+import { useAuth } from "./AuthContext";
+
+const NotificationContext = createContext({
+  notifications: [],
+  unreadCount: 0,
+  loading: false,
+  error: null,
+  refresh: () => {},
+  markAsRead: async () => {},
+  isEnabled: false,
+});
+
+export function NotificationProvider({ children }) {
+  const { token, user } = useAuth();
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const isEnabled = Boolean(token && user && user.role === "mentor");
+
+  const fetchNotifications = useCallback(async () => {
+    if (!isEnabled) {
+      setNotifications([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await apiClient.get("/mentors/notifications", token);
+      setNotifications(response.notifications || []);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [isEnabled, token]);
+
+  useEffect(() => {
+    if (!isEnabled) {
+      setNotifications([]);
+      return;
+    }
+
+    fetchNotifications();
+  }, [fetchNotifications, isEnabled]);
+
+  const markAsRead = useCallback(
+    async (notificationId) => {
+      if (!isEnabled || !notificationId) {
+        return;
+      }
+
+      try {
+        await apiClient.post(
+          `/mentors/notifications/${notificationId}/read`,
+          null,
+          token
+        );
+
+        setNotifications((previous) =>
+          previous.map((notification) =>
+            notification.id === notificationId
+              ? { ...notification, readAt: new Date().toISOString() }
+              : notification
+          )
+        );
+      } catch (err) {
+        setError(err.message);
+        throw err;
+      }
+    },
+    [isEnabled, token]
+  );
+
+  const value = useMemo(
+    () => ({
+      notifications,
+      unreadCount: notifications.filter((notification) => !notification.readAt)
+        .length,
+      loading,
+      error,
+      refresh: fetchNotifications,
+      markAsRead,
+      isEnabled,
+    }),
+    [notifications, loading, error, fetchNotifications, markAsRead, isEnabled]
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications() {
+  return useContext(NotificationContext);
+}

--- a/frontend/src/pages/MentorConnectionsPage.js
+++ b/frontend/src/pages/MentorConnectionsPage.js
@@ -3,8 +3,10 @@ import apiClient from "../api/client";
 import LoadingState from "../components/LoadingState";
 import MentorRequestList from "../components/MentorRequestList";
 import MentorProfileDialog from "../components/MentorProfileDialog";
+import NotificationList from "../components/NotificationList";
 import SectionCard from "../components/SectionCard";
 import { useAuth } from "../context/AuthContext";
+import { useNotifications } from "../context/NotificationContext";
 import {
   chipBaseClasses,
   emptyStateClasses,
@@ -25,6 +27,12 @@ function MentorConnectionsPage() {
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState(null);
   const [selectedMentor, setSelectedMentor] = useState(null);
+  const {
+    notifications,
+    loading: notificationsLoading,
+    markAsRead,
+    isEnabled: notificationsEnabled,
+  } = useNotifications();
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -113,6 +121,14 @@ function MentorConnectionsPage() {
     setMessage(`You ended your mentorship with ${request.mentor.name}.`);
   };
 
+  const handleNotificationRead = async (notificationId) => {
+    if (!notificationsEnabled) {
+      return;
+    }
+
+    await markAsRead(notificationId);
+  };
+
   if (loading) {
     return <LoadingState label="Loading mentorship" />;
   }
@@ -198,6 +214,19 @@ function MentorConnectionsPage() {
             </SectionCard>
           )}
         </>
+      )}
+
+      {notificationsEnabled && (
+        <SectionCard
+          title="Mentor notifications"
+          subtitle="Recent reflections shared by your mentees"
+        >
+          <NotificationList
+            notifications={notifications}
+            loading={notificationsLoading}
+            onMarkRead={handleNotificationRead}
+          />
+        </SectionCard>
       )}
 
       <SectionCard


### PR DESCRIPTION
## Summary
- add reusable mailer and notification utilities so mentor linking and entry submissions trigger privacy-aware email alerts
- introduce a notification context, bell menu, and shared list component to surface mentor notifications across the dashboard and mentorship pages
- document the end-to-end notification experience, including configuration and testing steps, in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb47dc8130833394fed8102de3b79b