### PR TITLE
feat: add tag-based mentor expertise management

### DIFF
--- a/frontend/src/components/MentorProfileDialog.js
+++ b/frontend/src/components/MentorProfileDialog.js
@@ -1,13 +1,17 @@
 import {
   bodyTextClasses,
   bodySmallMutedTextClasses,
+  chipBaseClasses,
   mediumHeadingClasses,
   primaryButtonClasses,
   secondaryButtonClasses,
 } from "../styles/ui";
+import { parseExpertise } from "../utils/expertise";
 
 function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
   if (!mentor) return null;
+
+  const expertiseTags = parseExpertise(mentor.expertise);
 
   const handleRequest = () => {
     if (typeof onRequest === "function") {
@@ -35,8 +39,14 @@ function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
             >
               {mentor.name}
             </h2>
-            {mentor.expertise && (
-              <p className={bodySmallMutedTextClasses}>{mentor.expertise}</p>
+            {expertiseTags.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {expertiseTags.map((tag) => (
+                  <span key={tag} className={chipBaseClasses}>
+                    {tag}
+                  </span>
+                ))}
+              </div>
             )}
             {mentor.email && (
               <p className={bodySmallMutedTextClasses}>{mentor.email}</p>

--- a/frontend/src/components/TagInput.js
+++ b/frontend/src/components/TagInput.js
@@ -1,0 +1,109 @@
+import { useMemo, useState } from "react";
+import { chipBaseClasses, inputClasses } from "../styles/ui";
+import { parseExpertise } from "../utils/expertise";
+
+function TagInput({
+  value = [],
+  onChange,
+  placeholder = "Add a tag and press Enter",
+  suggestions = [],
+  allowCustom = true,
+}) {
+  const [inputValue, setInputValue] = useState("");
+
+  const tags = useMemo(() => parseExpertise(value), [value]);
+
+  const availableSuggestions = useMemo(() => {
+    if (!Array.isArray(suggestions)) {
+      return [];
+    }
+    const tagSet = new Set(tags.map((tag) => tag.toLowerCase()));
+    return suggestions
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .filter((item) => !tagSet.has(item.toLowerCase()));
+  }, [suggestions, tags]);
+
+  const emitChange = (nextTags) => {
+    if (typeof onChange === "function") {
+      onChange(nextTags);
+    }
+  };
+
+  const addTag = (tag) => {
+    const trimmed = tag.trim();
+    if (!trimmed) {
+      return;
+    }
+    const normalized = trimmed.toLowerCase();
+    const exists = tags.some((existing) => existing.toLowerCase() === normalized);
+    if (exists) {
+      setInputValue("");
+      return;
+    }
+    emitChange([...tags, trimmed]);
+    setInputValue("");
+  };
+
+  const removeTag = (tag) => {
+    emitChange(tags.filter((item) => item !== tag));
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      if (allowCustom) {
+        addTag(inputValue);
+      }
+    } else if (event.key === "Backspace" && !inputValue) {
+      emitChange(tags.slice(0, -1));
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-emerald-200 bg-white/70 p-2 focus-within:border-emerald-300 focus-within:ring-2 focus-within:ring-emerald-100">
+        {tags.map((tag) => (
+          <span key={tag} className={`${chipBaseClasses} flex items-center gap-2`}> 
+            <span>{tag}</span>
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="rounded-full bg-emerald-100 px-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-200"
+              aria-label={`Remove ${tag}`}
+            >
+              ✕
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          className={`${inputClasses} h-9 min-w-[140px] flex-1 border-none bg-transparent px-2 py-1 text-sm shadow-none focus:ring-0 mt-0`}
+          placeholder={placeholder}
+        />
+      </div>
+      {availableSuggestions.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-emerald-800/70">
+            Suggested:
+          </span>
+          {availableSuggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              className={`${chipBaseClasses} transition hover:bg-emerald-100`}
+              onClick={() => addTag(suggestion)}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TagInput;

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -11,6 +11,7 @@ import {
   tableHeaderClasses,
   tableRowClasses,
 } from "../styles/ui";
+import { parseExpertise } from "../utils/expertise";
 
 function AdminDashboard() {
   const { token } = useAuth();
@@ -129,24 +130,35 @@ function AdminDashboard() {
       >
         {mentors.length ? (
           <ul className="grid gap-4">
-            {mentors.map((mentor) => (
-              <li
-                key={mentor.id}
-                className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-100 bg-white/70 p-5"
-              >
-                <div className="space-y-1">
-                  <p className="text-base font-semibold text-emerald-900">
-                    {mentor.name}
-                  </p>
-                  <p className={infoTextClasses}>
-                    {mentor.expertise || "Expertise not provided"}
-                  </p>
-                </div>
-                <span className={`${chipBaseClasses} text-xs uppercase`}> 
-                  {mentor.mentee_count} mentees
-                </span>
-              </li>
-            ))}
+            {mentors.map((mentor) => {
+              const expertiseTags = parseExpertise(mentor.expertise);
+              return (
+                <li
+                  key={mentor.id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-100 bg-white/70 p-5"
+                >
+                  <div className="space-y-1">
+                    <p className="text-base font-semibold text-emerald-900">
+                      {mentor.name}
+                    </p>
+                    {expertiseTags.length ? (
+                      <div className="flex flex-wrap gap-2">
+                        {expertiseTags.map((tag) => (
+                          <span key={tag} className={chipBaseClasses}>
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className={infoTextClasses}>Expertise not provided</p>
+                    )}
+                  </div>
+                  <span className={`${chipBaseClasses} text-xs uppercase`}>
+                    {mentor.mentee_count} mentees
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <p className={emptyStateClasses}>No mentors onboarded yet.</p>

--- a/frontend/src/pages/MentorConnectionsPage.js
+++ b/frontend/src/pages/MentorConnectionsPage.js
@@ -15,6 +15,7 @@ import {
   primaryButtonClasses,
   secondaryButtonClasses,
 } from "../styles/ui";
+import { parseExpertise } from "../utils/expertise";
 
 const ACTIVE_MENTOR_STATUSES = new Set(["pending", "mentor_accepted", "confirmed"]);
 
@@ -166,30 +167,43 @@ function MentorConnectionsPage() {
             >
               {mentors.length ? (
                 <ul className="grid gap-4">
-                  {mentors.map((mentor) => (
-                    <li
-                      key={mentor.id}
-                      className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-100 bg-white/70 p-5"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => setSelectedMentor(mentor)}
-                        className="group flex-1 space-y-1 text-left"
+                  {mentors.map((mentor) => {
+                    const expertiseTags = parseExpertise(mentor.expertise);
+                    return (
+                      <li
+                        key={mentor.id}
+                        className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-100 bg-white/70 p-5"
                       >
-                        <p className="text-base font-semibold text-emerald-900 group-hover:text-emerald-700">
-                          {mentor.name}
-                        </p>
-                        <p className={infoTextClasses}>{mentor.expertise || "Mentor"}</p>
-                      </button>
-                      <button
-                        type="button"
-                        className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
-                        onClick={() => sendRequest(mentor)}
-                      >
-                        Request mentorship
-                      </button>
-                    </li>
-                  ))}
+                        <button
+                          type="button"
+                          onClick={() => setSelectedMentor(mentor)}
+                          className="group flex-1 space-y-1 text-left"
+                        >
+                          <p className="text-base font-semibold text-emerald-900 group-hover:text-emerald-700">
+                            {mentor.name}
+                          </p>
+                          {expertiseTags.length ? (
+                            <div className="flex flex-wrap gap-2">
+                              {expertiseTags.map((tag) => (
+                                <span key={tag} className={chipBaseClasses}>
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          ) : (
+                            <p className={infoTextClasses}>Mentor</p>
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
+                          onClick={() => sendRequest(mentor)}
+                        >
+                          Request mentorship
+                        </button>
+                      </li>
+                    );
+                  })}
                 </ul>
               ) : (
                 <p className={emptyStateClasses}>No mentors match that search yet.</p>

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -15,6 +15,8 @@ import {
   xSmallHeadingClasses,
 } from "../styles/ui";
 import TIMEZONE_OPTIONS from "../utils/timezones";
+import TagInput from "../components/TagInput";
+import { formatExpertise, parseExpertise } from "../utils/expertise";
 
 const ROLES = [
   { value: "journaler", label: "Journaler" },
@@ -36,7 +38,7 @@ function RegisterPage() {
     role: "journaler",
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     mentorProfile: {
-      expertise: "",
+      expertise: [],
       availability: "",
       bio: "",
     },
@@ -54,6 +56,14 @@ function RegisterPage() {
     setForm((prev) => ({
       ...prev,
       mentorProfile: { ...prev.mentorProfile, [name]: value },
+    }));
+  };
+
+  const handleExpertiseChange = (nextExpertise) => {
+    setLocalError(null);
+    setForm((prev) => ({
+      ...prev,
+      mentorProfile: { ...prev.mentorProfile, expertise: parseExpertise(nextExpertise) },
     }));
   };
 
@@ -77,7 +87,10 @@ function RegisterPage() {
       };
 
       if (form.role === "mentor") {
-        payload.mentorProfile = form.mentorProfile;
+        payload.mentorProfile = {
+          ...form.mentorProfile,
+          expertise: formatExpertise(form.mentorProfile.expertise),
+        };
       }
 
       const response = await register(payload);
@@ -274,13 +287,10 @@ function RegisterPage() {
                 </h3>
                 <label className={`block ${formLabelClasses}`}>
                   Expertise
-                  <input
-                    type="text"
-                    name="expertise"
+                  <TagInput
                     value={form.mentorProfile.expertise}
-                    onChange={handleMentorChange}
-                    className={inputClasses}
-                    placeholder="What topics can you guide on?"
+                    onChange={handleExpertiseChange}
+                    placeholder="Press Enter to add each area of expertise"
                   />
                 </label>
                 <label className={`block ${formLabelClasses}`}>

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import SectionCard from "../components/SectionCard";
+import TagInput from "../components/TagInput";
 import { useAuth } from "../context/AuthContext";
 import {
   checkboxClasses,
@@ -12,6 +13,7 @@ import {
   textareaClasses,
 } from "../styles/ui";
 import TIMEZONE_OPTIONS from "../utils/timezones";
+import { formatExpertise, parseExpertise } from "../utils/expertise";
 
 function SettingsPage() {
   const { user, token, updateProfile, deleteAccount } = useAuth();
@@ -24,7 +26,7 @@ function SettingsPage() {
     mentorNotifications: "summary",
     password: "",
     mentorProfile: {
-      expertise: "",
+      expertise: [],
       availability: "",
       bio: "",
     },
@@ -35,6 +37,8 @@ function SettingsPage() {
 
   useEffect(() => {
     if (!user) return;
+    const mentorProfile = user.mentorProfile || { expertise: "", availability: "", bio: "" };
+
     setForm({
       name: user.name,
       email: user.email,
@@ -43,7 +47,11 @@ function SettingsPage() {
       remindersWeekly: user.notificationPreferences?.reminders?.weekly ?? true,
       mentorNotifications: user.notificationPreferences?.mentorNotifications || "summary",
       password: "",
-      mentorProfile: user.mentorProfile || { expertise: "", availability: "", bio: "" },
+      mentorProfile: {
+        expertise: parseExpertise(mentorProfile.expertise),
+        availability: mentorProfile.availability || "",
+        bio: mentorProfile.bio || "",
+      },
     });
   }, [user]);
 
@@ -60,6 +68,13 @@ function SettingsPage() {
     setForm((prev) => ({
       ...prev,
       mentorProfile: { ...prev.mentorProfile, [name]: value },
+    }));
+  };
+
+  const handleExpertiseChange = (nextExpertise) => {
+    setForm((prev) => ({
+      ...prev,
+      mentorProfile: { ...prev.mentorProfile, expertise: parseExpertise(nextExpertise) },
     }));
   };
 
@@ -116,7 +131,10 @@ function SettingsPage() {
       payload.password = form.password;
     }
     if (user.role === "mentor") {
-      payload.mentorProfile = form.mentorProfile;
+      payload.mentorProfile = {
+        ...form.mentorProfile,
+        expertise: formatExpertise(form.mentorProfile.expertise),
+      };
     }
 
     await updateProfile(payload);
@@ -273,12 +291,9 @@ function SettingsPage() {
               <h3 className="text-lg font-semibold text-emerald-900">Mentor profile</h3>
               <label className="block text-sm font-semibold text-emerald-900/80">
                 Expertise
-                <input
-                  type="text"
-                  name="expertise"
-                  className={inputClasses}
+                <TagInput
                   value={form.mentorProfile.expertise}
-                  onChange={handleMentorChange}
+                  onChange={handleExpertiseChange}
                 />
               </label>
               <label className="block text-sm font-semibold text-emerald-900/80">

--- a/frontend/src/utils/expertise.js
+++ b/frontend/src/utils/expertise.js
@@ -1,0 +1,41 @@
+export function parseExpertise(value) {
+  if (!value) {
+    return [];
+  }
+
+  const rawValues = Array.isArray(value)
+    ? value
+    : String(value)
+        .split(/[,\n;]+/)
+        .map((item) => item.trim());
+
+  const seen = new Set();
+
+  return rawValues
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .filter((item) => {
+      const normalized = item.toLowerCase();
+      if (seen.has(normalized)) {
+        return false;
+      }
+      seen.add(normalized);
+      return true;
+    });
+}
+
+export function formatExpertise(values) {
+  if (!values) {
+    return "";
+  }
+
+  const tags = Array.isArray(values) ? values : parseExpertise(values);
+  if (!tags.length) {
+    return "";
+  }
+
+  return tags
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .join(", ");
+}


### PR DESCRIPTION
## Summary
- add a reusable tag input and expertise formatting helpers
- update mentor registration and settings forms to capture expertise as tags while persisting comma-separated values
- render mentor expertise as chips across admin dashboards and mentor discovery views

## Testing
- npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4e9660d883339aa0e2a452115c43