### PR TITLE
Allow all roles to access notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ All endpoints are served from the `/api` prefix and return JSON. Supply an `Auth
 - `POST /api/mentors/requests/:id/confirm` – Journalers confirm an accepted request, establishing a mentor link. *(Journaler)*
 - `POST /api/mentors/requests/:id/decline` – Decline a request as the involved mentor or journaler. *(Authenticated)*
 - `GET /api/mentors/mentees` – Display linked journalers with their latest shared reflections. *(Mentor)*
-- `GET /api/mentors/notifications` – Retrieve the 50 most recent entry notifications shared by mentees. *(Mentor)*
-- `POST /api/mentors/notifications/:id/read` – Mark a notification as reviewed. *(Mentor)*
+- `GET /api/mentors/notifications` – Retrieve the 50 most recent entry notifications shared by mentees. *(Authenticated)*
+- `POST /api/mentors/notifications/:id/read` – Mark a notification as reviewed. *(Authenticated)*
 
 ### Dashboards & analytics
 

--- a/backend/routes/mentors.js
+++ b/backend/routes/mentors.js
@@ -444,7 +444,7 @@ router.get(
 router.get(
   "/notifications",
   authenticate,
-  requireRole("mentor"),
+  requireRole("mentor", "journaler", "admin"),
   async (req, res, next) => {
     try {
       const { rows } = await pool.query(
@@ -567,7 +567,7 @@ router.post(
 router.post(
   "/notifications/:id/read",
   authenticate,
-  requireRole("mentor"),
+  requireRole("mentor", "journaler", "admin"),
   async (req, res, next) => {
     try {
       const result = await pool.query(

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import NotificationList from "./NotificationList";
 import { useNotifications } from "../context/NotificationContext";
+import { useAuth } from "../context/AuthContext";
 import {
   bodySmallMutedTextClasses,
   iconButtonClasses,
@@ -16,6 +17,7 @@ function NotificationBell() {
     markAsRead,
     isEnabled,
   } = useNotifications();
+  const { user } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef(null);
   const panelRef = useRef(null);
@@ -65,6 +67,22 @@ function NotificationBell() {
   const handleMarkRead = async (notificationId) => {
     await markAsRead(notificationId);
   };
+
+  const helperText = (() => {
+    if (user?.role === "mentor") {
+      return "New entries appear here when mentees share reflections with you.";
+    }
+
+    if (user?.role === "journaler") {
+      return "Updates from your mentors and the Aleya team will appear here.";
+    }
+
+    if (user?.role === "admin") {
+      return "Platform alerts and recent changes will be listed here.";
+    }
+
+    return "Notifications will appear here when there are updates for your account.";
+  })();
 
   return (
     <div className="relative">
@@ -128,7 +146,7 @@ function NotificationBell() {
             limit={5}
           />
           <p className={`${bodySmallMutedTextClasses} mt-3 text-emerald-900/70`}>
-            New entries appear here when mentees share reflections with you.
+            {helperText}
           </p>
         </div>
       )}

--- a/frontend/src/components/NotificationList.js
+++ b/frontend/src/components/NotificationList.js
@@ -105,7 +105,7 @@ function NotificationList({
             <div className="space-y-2">
               <div className="space-y-1">
                 <p className="text-base font-semibold text-emerald-900">
-                  {notification.journaler?.name || "Mentee update"}
+                  {notification.journaler?.name || "Shared update"}
                 </p>
                 <p className={infoTextClasses}>
                   {entryDate ? `${entryDate} · ` : ""}

--- a/frontend/src/context/NotificationContext.js
+++ b/frontend/src/context/NotificationContext.js
@@ -18,7 +18,7 @@ export function NotificationProvider({ children }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const isEnabled = Boolean(token && user && user.role === "mentor");
+  const isEnabled = Boolean(token && user);
 
   const fetchNotifications = useCallback(async () => {
     if (!isEnabled) {

--- a/frontend/src/pages/MentorConnectionsPage.js
+++ b/frontend/src/pages/MentorConnectionsPage.js
@@ -230,7 +230,7 @@ function MentorConnectionsPage() {
         </>
       )}
 
-      {notificationsEnabled && (
+      {user.role === "mentor" && notificationsEnabled && (
         <SectionCard
           title="Mentor notifications"
           subtitle="Recent reflections shared by your mentees"


### PR DESCRIPTION
## Summary
- allow any authenticated role to access notification endpoints in the mentors router
- enable the frontend notification context and bell for all signed-in users with role-specific messaging
- tweak mentor connections page and documentation to reflect the broader notification availability

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb541dfaa883339efd89a59d570739