### PR TITLE
Allow journalers to end mentorship without password

### DIFF
--- a/backend/routes/mentors.js
+++ b/backend/routes/mentors.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const { body, validationResult } = require("express-validator");
-const bcrypt = require("bcryptjs");
 const pool = require("../db");
 const authenticate = require("../middleware/auth");
 const requireRole = require("../middleware/requireRole");
@@ -285,7 +284,6 @@ router.delete(
   "/links/:mentorId",
   authenticate,
   requireRole("journaler"),
-  [body("password").isString().notEmpty().withMessage("Password is required")],
   async (req, res, next) => {
     const mentorId = Number(req.params.mentorId);
 
@@ -293,26 +291,7 @@ router.delete(
       return res.status(400).json({ error: "Invalid mentor id" });
     }
 
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
-    }
-
     try {
-      const { rows } = await pool.query(
-        `SELECT password_hash FROM users WHERE id = $1`,
-        [req.user.id]
-      );
-
-      if (!rows.length) {
-        return res.status(401).json({ error: "User not found" });
-      }
-
-      const isValid = await bcrypt.compare(req.body.password, rows[0].password_hash);
-      if (!isValid) {
-        return res.status(401).json({ error: "Incorrect password" });
-      }
-
       const client = await pool.connect();
 
       try {


### PR DESCRIPTION
## Summary
- remove the password requirement from the journaler endpoint that ends a mentorship link
- rely on the authenticated user context to locate and delete the mentor link plus related records

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb5816cb188333bfde8dae40a6ae73