### PR TITLE
Improve landing page mobile experience

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -125,7 +125,7 @@ function Layout({ children }) {
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-br from-emerald-50 via-white to-emerald-100 text-emerald-950">
       <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/80 backdrop-blur">
-        <div className="mx-auto w-full max-w-6xl px-6 py-4">
+        <div className="mx-auto w-full max-w-6xl px-4 py-4 sm:px-6">
           <div className="flex items-center gap-4">
             <button
               type="button"
@@ -230,12 +230,12 @@ function Layout({ children }) {
           )}
         </div>
       </header>
-      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-12">
+      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-4 pb-16 pt-10 sm:px-6 sm:py-12">
         {children}
       </main>
       <footer className="border-t border-emerald-100 bg-white/70">
         <div
-          className={`mx-auto w-full max-w-6xl px-6 py-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}
+          className={`mx-auto w-full max-w-6xl px-4 py-6 text-center sm:px-6 ${bodySmallMutedTextClasses} text-emerald-900/70`}
         >
           Root your days in care, grow with guidance, and share the harvest.
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -108,47 +108,47 @@
   }
 
   .text-display {
-    @apply text-4xl font-bold tracking-tight sm:text-5xl;
+    @apply text-[2.5rem] font-bold leading-tight tracking-tight sm:text-5xl md:text-6xl;
   }
 
   .text-heading-lg {
-    @apply text-3xl font-semibold;
+    @apply text-[2rem] font-semibold leading-snug md:text-3xl;
   }
 
   .text-heading-md {
-    @apply text-2xl font-semibold;
+    @apply text-[1.625rem] font-semibold leading-snug md:text-2xl;
   }
 
   .text-heading-sm {
-    @apply text-xl font-semibold;
+    @apply text-[1.35rem] font-semibold leading-snug md:text-xl;
   }
 
   .text-heading-xs {
-    @apply text-lg font-semibold;
+    @apply text-lg font-semibold leading-snug md:text-[1.125rem];
   }
 
   .text-body-lg {
-    @apply text-lg leading-relaxed;
+    @apply text-[1.15rem] leading-relaxed md:text-lg;
   }
 
   .text-body {
-    @apply text-base leading-relaxed;
+    @apply text-[1.05rem] leading-relaxed md:text-base;
   }
 
   .text-body-strong {
-    @apply text-base font-semibold;
+    @apply text-[1.05rem] font-semibold leading-relaxed md:text-base;
   }
 
   .text-body-muted {
-    @apply text-base text-emerald-900/70;
+    @apply text-[1.05rem] leading-relaxed text-emerald-900/70 md:text-base;
   }
 
   .text-body-sm {
-    @apply text-sm;
+    @apply text-base leading-relaxed md:text-sm;
   }
 
   .text-body-sm-strong {
-    @apply text-sm font-semibold;
+    @apply text-base font-semibold leading-relaxed md:text-sm;
   }
 
   .text-eyebrow {
@@ -156,7 +156,7 @@
   }
 
   .text-caption {
-    @apply text-xs font-semibold uppercase tracking-wide;
+    @apply text-[0.8rem] font-semibold uppercase tracking-wide md:text-xs;
   }
 
   .form-label {
@@ -164,6 +164,6 @@
   }
 
   .text-body-sm-muted {
-    @apply text-sm text-emerald-900/70;
+    @apply text-base leading-relaxed text-emerald-900/70 md:text-sm;
   }
 }

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -14,11 +14,11 @@ import {
 
 function LandingPage() {
   return (
-    <div className="flex w-full flex-1 flex-col gap-12 text-emerald-900">
-      <section className="grid gap-10 rounded-3xl border border-emerald-100 bg-white/80 p-10 shadow-xl shadow-emerald-900/10 backdrop-blur md:grid-cols-[1.1fr_1fr]">
-        <div className="space-y-6">
+    <div className="flex w-full flex-1 flex-col gap-14 text-emerald-900">
+      <section className="grid gap-10 rounded-[2rem] bg-white/90 p-6 shadow-lg shadow-emerald-900/10 backdrop-blur sm:p-8 md:grid-cols-[1.05fr_1fr] md:gap-12 md:border md:border-emerald-100 md:bg-white/80 md:p-12 md:shadow-xl">
+        <div className="space-y-6 sm:space-y-8">
           <div
-            className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
+            className={`inline-flex items-center gap-2 rounded-full border border-emerald-200/70 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
           >
             🌿 Grow whole
           </div>
@@ -27,18 +27,18 @@ function LandingPage() {
           </h1>
           <p className={`${leadTextClasses} text-emerald-900/80`}>
             Aleya weaves journaling, mentorship, and gentle accountability so you can
-            notice your emotions, nurture your habits, and share progress with the
-            guides who support you.
+            notice your emotions, nurture your habits, and share progress with the guides
+            who support you.
           </p>
-          <div className="flex flex-wrap gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
             <Link
-              className={`${primaryButtonClasses} px-6 py-3 text-base`}
+              className={`${primaryButtonClasses} w-full justify-center px-6 py-3 text-base sm:w-auto`}
               to="/register"
             >
               Start journaling
             </Link>
             <Link
-              className={`${secondaryButtonClasses} px-6 py-3 text-base`}
+              className={`${secondaryButtonClasses} w-full justify-center px-6 py-3 text-base sm:w-auto`}
               to="/login"
             >
               I already have an account
@@ -46,7 +46,7 @@ function LandingPage() {
           </div>
         </div>
         <div className="space-y-4">
-          <div className="overflow-hidden rounded-3xl border border-emerald-200 text-white shadow-lg shadow-emerald-900/10">
+          <div className="overflow-hidden rounded-[1.75rem] shadow-lg shadow-emerald-900/10 md:border md:border-emerald-200">
             <div className="grid text-left">
               <TreeLayer
                 title="Roots · Self-care"
@@ -73,7 +73,7 @@ function LandingPage() {
         </div>
       </section>
 
-      <section className="grid gap-6 md:grid-cols-3">
+      <section className="grid gap-5 sm:grid-cols-2 md:grid-cols-3">
         <FeatureCard
           title="Journalers"
           description="Build a meaningful check-in ritual, track your mood, and celebrate streaks with visual dashboards."
@@ -88,11 +88,11 @@ function LandingPage() {
         />
       </section>
 
-      <section className="rounded-3xl bg-emerald-600 px-8 py-10 text-white shadow-xl shadow-emerald-900/20">
+      <section className="rounded-[2rem] bg-emerald-600 p-6 text-white shadow-xl shadow-emerald-900/20 sm:p-8 md:p-12">
         <h2 className={`${largeHeadingClasses} tracking-tight`}>
           Your day is a living ecosystem.
         </h2>
-        <p className={`mt-4 ${leadTextClasses} text-white/80`}>
+        <p className={`mt-4 ${leadTextClasses} text-white/90`}>
           Aleya keeps the ecosystem connected—so when you tend to sleep, learning,
           relationships, and creative sparks, you can see the whole tree flourish.
         </p>
@@ -103,20 +103,18 @@ function LandingPage() {
 
 function FeatureCard({ title, description }) {
   return (
-    <article className="rounded-3xl border border-emerald-100 bg-white/70 p-6 shadow-inner shadow-emerald-900/5">
+    <article className="flex flex-col gap-3 rounded-2xl bg-white/80 p-5 shadow-sm shadow-emerald-900/10 backdrop-blur sm:gap-4 sm:rounded-3xl sm:p-6 md:border md:border-emerald-100 md:shadow-inner">
       <h2 className={`${smallHeadingClasses} text-emerald-900`}>{title}</h2>
-      <p className={`mt-3 ${bodySmallMutedTextClasses} text-emerald-900/70`}>{description}</p>
+      <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>{description}</p>
     </article>
   );
 }
 
 function TreeLayer({ title, description, className }) {
   return (
-    <div className={`space-y-2 px-6 py-5 ${className}`}>
-      <span className={`${captionTextClasses} text-white/80`}>
-        {title}
-      </span>
-      <p className={`${bodySmallTextClasses} leading-relaxed text-white/80`}>{description}</p>
+    <div className={`space-y-2 px-5 py-5 sm:px-6 sm:py-6 ${className}`}>
+      <span className={`${captionTextClasses} text-white/80`}>{title}</span>
+      <p className={`${bodySmallTextClasses} text-white/90`}>{description}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- scale typography tokens to improve readability on small screens while keeping desktop sizing
- refresh landing page hero and feature sections with cleaner mobile spacing and responsive button layouts
- adjust shared layout padding to give phone viewports more usable content width

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb5b3eecd08333b7df6c64e6caad0f