### PR TITLE
Handle HTML proxy error pages gracefully

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,0 +1,5 @@
+# Aleya Project Wiki
+
+## 2025-02-15 - Stabilize API error handling
+- Hardened the shared frontend API client so HTML proxy error pages (e.g., Cloudflare 502 responses) are converted into human readable status messages instead of being rendered directly in the UI.
+- Documented expectation for feature work to surface `apiClient` error messages rather than raw response bodies.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -7,3 +7,5 @@
   - Helper styles: `card-container`, `empty-state`, `text-info`, `text-muted`, `chip-base`, `badge-base`.
 - When composing new components, import the relevant constants from `src/styles/ui.js` instead of hard-coding class strings. This keeps the font stack and sizing consistent across the app.
 - Update this document if you introduce new design tokens so future changes remain consistent.
+- The shared API client normalizes error responses and strips HTML payloads from upstream proxies. When handling errors, rely on
+  the `message` field returned by `apiClient` instead of rendering raw response bodies.

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -18,13 +18,28 @@ async function request(path, { method = "GET", data, token, headers = {} } = {})
   }
 
   const response = await fetch(`${API_BASE_URL}${path}`, config);
+  const contentType = response.headers.get("content-type") || "";
   const text = await response.text();
-  let payload;
+  let payload = {};
 
-  try {
-    payload = text ? JSON.parse(text) : {};
-  } catch (error) {
-    payload = { message: text };
+  const isJson = contentType.includes("application/json");
+
+  if (isJson) {
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch (error) {
+      payload = { message: "Received malformed JSON from the server.", raw: text };
+    }
+  } else if (text) {
+    const trimmedText = text.trim();
+    if (trimmedText.startsWith("<!DOCTYPE") || trimmedText.startsWith("<html")) {
+      payload = {
+        message: response.statusText || "The server is currently unavailable. Please try again later.",
+        raw: text,
+      };
+    } else {
+      payload = { message: trimmedText };
+    }
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- normalize frontend API client error handling so HTML proxy responses surface friendly messages
- document the error-handling behavior in the frontend contributor guide and project wiki

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb6788aa0483339f559a959cae1652