### PR TITLE
Fix panic alert route middleware syntax

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,5 @@
+# Backend Agent Notes
+
+- When changing backend routes or utilities, run `node --check <file>` on the touched modules to catch syntax issues early.
+- Keep mentor panic alert flows consistent with mentor escalation requirements and ensure new middleware is added as individual arguments instead of wrapped arrays when Express parsing causes issues.
+- Document all backend changes in `docs/Wiki.md` so future contributors understand the context behind updates.

--- a/backend/routes/mentors.js
+++ b/backend/routes/mentors.js
@@ -496,14 +496,12 @@ router.post(
   "/panic-alerts",
   authenticate,
   requireRole("mentor"),
-  [
-    body("mentorId").isInt({ gt: 0 }).withMessage("mentorId is required"),
-    body("message")
-      .isString()
-      .trim()
-      .isLength({ min: 1, max: 500 })
-      .withMessage("A short message is required"),
-  ],
+  body("mentorId").isInt({ gt: 0 }).withMessage("mentorId is required"),
+  body("message")
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 500 })
+    .withMessage("A short message is required"),
   async (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,0 +1,6 @@
+# Repository Wiki
+
+## 2025-09-18
+- Adjusted the mentor panic alert route to list each validator middleware individually instead of wrapping them in an array. This resolves a syntax parsing error observed when Docker booted the backend and keeps Express middleware handling straightforward.
+- Confirmed the route still requires mentors to be authenticated before sending panic alerts, aligning with the README description of the feature.
+- Added `backend/AGENTS.md` to capture backend-specific contributing notes and remind developers to update this wiki when changes are made.


### PR DESCRIPTION
## Summary
- register the panic alert validation middleware as individual arguments to eliminate the syntax error reported by nodemon
- add backend-specific AGENTS guidance and document the fix in `docs/Wiki.md`

## Testing
- node --check backend/routes/mentors.js

------
https://chatgpt.com/codex/tasks/task_e_68cb6db09610833390260ba1c086cf23