### PR TITLE
Fix panic alert route syntax

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -3,3 +3,4 @@
 - When changing backend routes or utilities, run `node --check <file>` on the touched modules to catch syntax issues early.
 - Keep mentor panic alert flows consistent with mentor escalation requirements and ensure new middleware is added as individual arguments instead of wrapped arrays when Express parsing causes issues.
 - Document all backend changes in `docs/Wiki.md` so future contributors understand the context behind updates.
+- Double-check route definitions end with their closing `);` pair so `node --check` passes before pushing changes.

--- a/backend/routes/mentors.js
+++ b/backend/routes/mentors.js
@@ -520,4 +520,6 @@ router.post(
       return next(error);
     }
   }
+);
+
 module.exports = router;

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,10 @@
 # Repository Wiki
 
+## 2025-09-19
+- Fixed the mentor panic alert route definition in `backend/routes/mentors.js` by restoring the missing closing `);` so Docker n
+  odemon no longer crashes on startup.
+- Updated `backend/AGENTS.md` to remind contributors to confirm route endings while running `node --check` on touched files.
+
 ## 2025-09-18
 - Adjusted the mentor panic alert route to list each validator middleware individually instead of wrapping them in an array. This resolves a syntax parsing error observed when Docker booted the backend and keeps Express middleware handling straightforward.
 - Confirmed the route still requires mentors to be authenticated before sending panic alerts, aligning with the README description of the feature.


### PR DESCRIPTION
## Summary
- restore the missing closing `);` on the mentor panic alert route so the backend starts without syntax errors
- update backend contribution guidelines to remind developers to verify route endings during `node --check`
- document the fix in the repository wiki for future contributors

## Testing
- node --check backend/routes/mentors.js

------
https://chatgpt.com/codex/tasks/task_e_68cb71ddcdc08333be0765b1997a8d88