### PR TITLE
Center SOS modal overlay

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,10 @@
 # Repository Wiki
 
+## 2025-09-20
+- Centered the SOS modal in `frontend/src/components/PanicButton.js` and constrained its height so it no longer renders off the
+  top of the viewport on smaller screens.
+- Documented the modal layout guidance in `frontend/AGENTS.md` to keep future overlays aligned and scrollable.
+
 ## 2025-09-19
 - Fixed the mentor panic alert route definition in `backend/routes/mentors.js` by restoring the missing closing `);` so Docker n
   odemon no longer crashes on startup.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -7,3 +7,6 @@
   - Helper styles: `card-container`, `empty-state`, `text-info`, `text-muted`, `chip-base`, `badge-base`.
 - When composing new components, import the relevant constants from `src/styles/ui.js` instead of hard-coding class strings. This keeps the font stack and sizing consistent across the app.
 - Update this document if you introduce new design tokens so future changes remain consistent.
+- For modal overlays, center panels with `fixed inset-0 flex min-h-screen items-center justify-center` and wrap the panel
+  content in a scrollable container (e.g. `max-h-[min(85vh,40rem)] overflow-y-auto`) so longer forms remain visible on smaller
+  screens.

--- a/frontend/src/components/PanicButton.js
+++ b/frontend/src/components/PanicButton.js
@@ -121,21 +121,22 @@ function PanicButton() {
 
       {isOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-emerald-950/40 px-4 py-10"
+          className="fixed inset-0 z-50 flex min-h-screen items-center justify-center bg-emerald-950/40 p-4 sm:p-6"
           role="dialog"
           aria-modal="true"
           aria-labelledby="sos-dialog-heading"
           onClick={closeDialog}
         >
           <div
-            className="relative w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl sm:p-8"
+            className="relative w-full max-w-lg overflow-hidden rounded-3xl bg-white shadow-2xl"
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1">
-                <h2
-                  id="sos-dialog-heading"
-                  className="text-xl font-semibold text-emerald-900"
+            <div className="max-h-[min(85vh,40rem)] overflow-y-auto p-6 sm:p-8">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <h2
+                    id="sos-dialog-heading"
+                    className="text-xl font-semibold text-emerald-900"
                 >
                   Request urgent support
                 </h2>


### PR DESCRIPTION
## Summary
- center the SOS dialog overlay within the viewport and allow the panel to scroll when space is limited
- document the preferred modal layout pattern for the frontend in AGENTS.md
- record the SOS modal fix in the project wiki for future reference

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb73e5f340833395447f8359c6b0cc