### PR TITLE
Center SOS modal and add cancel control

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,9 @@
+# 2025-09-21
+- Added a secondary cancel action to the SOS modal in `frontend/src/components/PanicButton.js` using the shared `btn-secondary`
+  token so people can close the dialog without reaching the header button.
+- Adjusted the SOS overlay container spacing to keep the panel vertically centered instead of hugging the top edge of the
+  viewport.
+
 # Repository Wiki
 
 ## 2025-09-20

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -10,3 +10,5 @@
 - For modal overlays, center panels with `fixed inset-0 flex min-h-screen items-center justify-center` and wrap the panel
   content in a scrollable container (e.g. `max-h-[min(85vh,40rem)] overflow-y-auto`) so longer forms remain visible on smaller
   screens.
+- Pair destructive or primary modal actions with a secondary "Cancel" control that uses `btn-secondary` so people always have
+  a clear escape hatch.

--- a/frontend/src/components/PanicButton.js
+++ b/frontend/src/components/PanicButton.js
@@ -121,7 +121,7 @@ function PanicButton() {
 
       {isOpen && (
         <div
-          className="fixed inset-0 z-50 flex min-h-screen items-center justify-center bg-emerald-950/40 p-4 sm:p-6"
+          className="fixed inset-0 z-50 flex min-h-screen items-center justify-center bg-emerald-950/40 px-4 py-6 sm:px-6 sm:py-10"
           role="dialog"
           aria-modal="true"
           aria-labelledby="sos-dialog-heading"
@@ -209,7 +209,15 @@ function PanicButton() {
                     <p className="text-sm text-emerald-600">{success}</p>
                   )}
 
-                  <div className="flex justify-end">
+                  <div className="flex justify-end gap-3">
+                    <button
+                      type="button"
+                      className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                      onClick={closeDialog}
+                      disabled={sending}
+                    >
+                      Cancel
+                    </button>
                     <button
                       type="submit"
                       className={`${dangerButtonClasses} px-5 py-2.5 text-sm`}


### PR DESCRIPTION
## Summary
- adjust the SOS overlay spacing so the panic dialog stays vertically centered on the viewport
- add a secondary cancel action to the SOS form using the shared button tokens and document the pattern in the frontend guide
- record the modal updates in the repository wiki for future reference

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb7672d4548333a38a930a10e49e91