### PR TITLE
Refresh Aleya frontend copy with poetic tone

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -25,3 +25,7 @@
 - Adjusted the mentor panic alert route to list each validator middleware individually instead of wrapping them in an array. This resolves a syntax parsing error observed when Docker booted the backend and keeps Express middleware handling straightforward.
 - Confirmed the route still requires mentors to be authenticated before sending panic alerts, aligning with the README description of the feature.
 - Added `backend/AGENTS.md` to capture backend-specific contributing notes and remind developers to update this wiki when changes are made.
+# 2025-09-22
+- Rewrote major frontend copy (landing, authentication, dashboards, notifications, SOS modal) with Aleya’s poetic grove tone so the experience feels consistently luminous and nature-infused.
+- Updated `frontend/AGENTS.md` to note the new copy voice guidance for future contributors.
+

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -9,6 +9,7 @@
   - Helper styles: `card-container`, `empty-state`, `text-info`, `text-muted`, `chip-base`, `badge-base`.
 - When composing new components, import the relevant constants from `src/styles/ui.js` instead of hard-coding class strings. This keeps the font stack and sizing consistent across the app.
 - Update this document if you introduce new design tokens so future changes remain consistent.
+- When updating copy, honor Aleya’s luminous grove tone: poetic, gentle, and nature-infused while keeping guidance clear.
 - For modal overlays, center panels with `fixed inset-0 flex min-h-screen items-center justify-center` and wrap the panel
   content in a scrollable container (e.g. `max-h-[min(85vh,40rem)] overflow-y-auto`) so longer forms remain visible on smaller
   screens.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,7 +33,7 @@ function ProtectedRoute({ roles, children }) {
   const { user, loading } = useAuth();
 
   if (loading) {
-    return <LoadingState label="Preparing Aleya" />;
+    return <LoadingState label="Lighting the Aleya path" />;
   }
 
   if (!user) {

--- a/frontend/src/components/JournalEntryForm.js
+++ b/frontend/src/components/JournalEntryForm.js
@@ -15,10 +15,10 @@ import {
 
 const DEFAULT_SHARING = "private";
 const SHARING_OPTIONS = [
-  { value: "private", label: "Keep private" },
+  { value: "private", label: "Keep in my private sanctuary" },
   { value: "mood", label: "Share mood only" },
   { value: "summary", label: "Share summary" },
-  { value: "full", label: "Share full entry" },
+  { value: "full", label: "Share the full reflection" },
 ];
 
 function JournalEntryForm({
@@ -70,7 +70,7 @@ function JournalEntryForm({
   }, [form, values]);
 
   if (!form) {
-    return <p className={emptyStateClasses}>Select a form to start journaling.</p>;
+    return <p className={emptyStateClasses}>Select a form to begin today’s reflection.</p>;
   }
 
   const handleChange = (field, value) => {
@@ -80,7 +80,7 @@ function JournalEntryForm({
   const handleSubmit = (event) => {
     event.preventDefault();
     if (!canSubmit) {
-      setError("Please complete all required fields.");
+      setError("Please complete each required prompt.");
       return;
     }
 
@@ -143,7 +143,7 @@ function JournalEntryForm({
           ))}
         </select>
         <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
-          Control what mentors can see when you submit entries.
+          Decide how much of this entry your mentors can see.
         </p>
       </div>
       {error && (

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -113,10 +113,10 @@ function Layout({ children }) {
     return (
       <div className={containerClasses}>
         <NavLink to="/login" className={signInClasses} onClick={handleNavigate}>
-          Sign in
+          Step inside
         </NavLink>
         <NavLink to="/register" className={joinClasses} onClick={handleNavigate}>
-          Join Aleya
+          Join the Aleya canopy
         </NavLink>
       </div>
     );
@@ -237,7 +237,7 @@ function Layout({ children }) {
         <div
           className={`mx-auto w-full max-w-6xl px-6 py-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}
         >
-          Root your days in care, grow with guidance, and share the harvest.
+          Tend your breath, follow the light, and share the harvest of your days.
         </div>
       </footer>
     </div>

--- a/frontend/src/components/LoadingState.js
+++ b/frontend/src/components/LoadingState.js
@@ -1,4 +1,4 @@
-function LoadingState({ label = "Loading", compact = false }) {
+function LoadingState({ label = "Gathering the morning light", compact = false }) {
   const containerClasses = compact
     ? "flex items-center justify-center text-sm font-medium text-emerald-900/70"
     : "flex min-h-[40vh] items-center justify-center text-sm font-medium text-emerald-900/70";

--- a/frontend/src/components/MentorProfileDialog.js
+++ b/frontend/src/components/MentorProfileDialog.js
@@ -82,7 +82,7 @@ function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
 
           {!mentor.availability && !mentor.bio && (
             <p className={bodySmallMutedTextClasses}>
-              This mentor hasn&apos;t shared a detailed profile yet.
+              This mentor hasn&apos;t shared their story yet, but their lantern is lit.
             </p>
           )}
         </div>

--- a/frontend/src/components/MentorRequestList.js
+++ b/frontend/src/components/MentorRequestList.js
@@ -15,7 +15,7 @@ function MentorRequestList({
 }) {
   if (!requests.length) {
     return (
-      <p className={emptyStateClasses}>No mentorship requests at the moment.</p>
+      <p className={emptyStateClasses}>No mentorship invitations right now—the sky is briefly clear.</p>
     );
   }
 
@@ -97,15 +97,15 @@ function MentorRequestList({
 function formatStatus(status) {
   switch (status) {
     case "pending":
-      return "Awaiting response";
+      return "Awaiting your welcome";
     case "mentor_accepted":
-      return "Mentor accepted";
+      return "Mentor has accepted";
     case "confirmed":
-      return "Linked";
+      return "Bond confirmed";
     case "declined":
       return "Declined";
     case "ended":
-      return "Mentorship ended";
+      return "Mentorship closed";
     default:
       return status;
   }

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -70,18 +70,18 @@ function NotificationBell() {
 
   const helperText = (() => {
     if (user?.role === "mentor") {
-      return "New entries appear here when mentees share reflections with you. Adjust what you receive in Settings.";
+      return "Mentee reflections glow here when they choose to share. Adjust the lanterns you receive in Settings.";
     }
 
     if (user?.role === "journaler") {
-      return "Updates from your mentors and the Aleya team will appear here. Manage your preferences in Settings.";
+      return "Mentor replies and Aleya updates gather here. Shape the flow in Settings.";
     }
 
     if (user?.role === "admin") {
-      return "Platform alerts and recent changes will be listed here. Fine-tune categories in Settings.";
+      return "Platform signals and recent changes shimmer here. Tune the categories in Settings.";
     }
 
-    return "Notifications will appear here when there are updates for your account. You can control channels in Settings.";
+    return "Updates will appear here whenever Aleya needs your attention. Choose your channels in Settings.";
   })();
 
   return (
@@ -136,7 +136,7 @@ function NotificationBell() {
                 navigate("/dashboard");
               }}
             >
-              View dashboard
+              View full dashboard
             </button>
           </div>
           <NotificationList

--- a/frontend/src/components/NotificationList.js
+++ b/frontend/src/components/NotificationList.js
@@ -23,11 +23,11 @@ function NotificationList({
   notifications,
   onMarkRead,
   loading = false,
-  emptyLabel = "You're all caught up.",
+  emptyLabel = "The lantern is quiet for now.",
   limit,
 }) {
   if (loading) {
-    return <LoadingState label="Loading notifications" compact />;
+    return <LoadingState label="Gathering shared lanterns" compact />;
   }
 
   const visibleNotifications = Array.isArray(notifications)
@@ -101,7 +101,7 @@ function NotificationList({
                 )}
                 {createdAt && (
                   <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
-                    Sent {createdAt}
+                    Lantern lit {createdAt}
                   </p>
                 )}
               </div>

--- a/frontend/src/components/PanicButton.js
+++ b/frontend/src/components/PanicButton.js
@@ -53,7 +53,7 @@ function PanicButton() {
       const response = await apiClient.get("/mentors/support-network", token);
       setContacts(response.mentors || []);
     } catch (err) {
-      setError(err.message || "Unable to load mentors.");
+      setError(err.message || "Unable to reach your circle of mentors.");
     } finally {
       setLoading(false);
     }
@@ -68,11 +68,11 @@ function PanicButton() {
   const handleSubmit = async (event) => {
     event.preventDefault();
     if (!selectedMentor) {
-      setError("Select a mentor to contact.");
+      setError("Choose a mentor to receive your flare.");
       return;
     }
     if (!message.trim()) {
-      setError("Add a brief note before sending.");
+      setError("Add a brief note so your mentor knows how to arrive.");
       return;
     }
 
@@ -92,12 +92,12 @@ function PanicButton() {
       );
       setSuccess(
         target?.name
-          ? `SOS alert sent to ${target.name}.`
-          : "SOS alert sent successfully."
+          ? `Aleya has carried your SOS to ${target.name}.`
+          : "Aleya has carried your SOS."
       );
       setMessage("");
     } catch (err) {
-      setError(err.message || "Failed to send SOS alert.");
+      setError(err.message || "Aleya could not send the SOS. Try again in a moment.");
     } finally {
       setSending(false);
     }
@@ -137,13 +137,13 @@ function PanicButton() {
                   <h2
                     id="sos-dialog-heading"
                     className="text-xl font-semibold text-emerald-900"
-                >
-                  Request urgent support
-                </h2>
-                <p className={bodySmallMutedTextClasses}>
-                  Choose a mentor you are linked with and share why you need immediate help.
-                </p>
-              </div>
+                  >
+                    Send a flare for support
+                  </h2>
+                  <p className={bodySmallMutedTextClasses}>
+                    Choose a linked mentor and share why you need immediate care so they can arrive prepared.
+                  </p>
+                </div>
               <button
                 type="button"
                 className={`${secondaryButtonClasses} px-4 py-2 text-sm`}
@@ -155,12 +155,12 @@ function PanicButton() {
 
             <div className="mt-6 space-y-4">
               {loading && (
-                <p className={bodySmallMutedTextClasses}>Loading mentors…</p>
+                <p className={bodySmallMutedTextClasses}>Calling your mentors…</p>
               )}
 
               {!loading && !hasContacts && !error && (
                 <p className={bodySmallMutedTextClasses}>
-                  You are not linked with any mentors yet. Invite a mentor to enable SOS alerts.
+                  You are not yet linked with mentors. Invite one to activate this SOS lantern.
                 </p>
               )}
 
@@ -168,7 +168,7 @@ function PanicButton() {
                 <form className="space-y-5" onSubmit={handleSubmit}>
                   <div className="space-y-2">
                     <label className={bodySmallStrongTextClasses} htmlFor="sos-mentor">
-                      Contact
+                      Reach out to
                     </label>
                     <select
                       id="sos-mentor"
@@ -194,7 +194,7 @@ function PanicButton() {
                       id="sos-message"
                       className={textareaClasses}
                       rows={4}
-                      placeholder="Share context so they know how to help right away."
+                      placeholder="Share context so they can meet you right away."
                       value={message}
                       onChange={(event) => setMessage(event.target.value)}
                       disabled={sending}
@@ -223,7 +223,7 @@ function PanicButton() {
                       className={`${dangerButtonClasses} px-5 py-2.5 text-sm`}
                       disabled={sending}
                     >
-                      {sending ? "Sending…" : "Send SOS alert"}
+                      {sending ? "Sending…" : "Send SOS lantern"}
                     </button>
                   </div>
                 </form>

--- a/frontend/src/pages/JournalerDashboard.js
+++ b/frontend/src/pages/JournalerDashboard.js
@@ -143,7 +143,7 @@ function JournalerDashboard() {
   const handleSubmit = async (payload) => {
     setSubmitting(true);
     setStatusVariant("info");
-    setStatusMessage("Submitting your journal entry...");
+    setStatusMessage("Sending your reflection into the grove...");
     setError(null);
 
     try {
@@ -152,7 +152,7 @@ function JournalerDashboard() {
       const dash = await apiClient.get("/dashboard/journaler", token);
       setDashboard(dash);
       setStatusVariant("success");
-      setStatusMessage("Journal entry saved.");
+      setStatusMessage("Your reflection now sings within Aleya.");
       setFormResetKey((prev) => prev + 1);
     } catch (err) {
       setStatusVariant("info");
@@ -164,14 +164,14 @@ function JournalerDashboard() {
   };
 
   if (loading && !dashboard) {
-    return <LoadingState label="Loading dashboard" />;
+    return <LoadingState label="Illuminating your canopy" />;
   }
 
   return (
     <div className="flex w-full flex-1 flex-col gap-8">
       <SectionCard
         title={`Welcome back, ${user?.name || "friend"}`}
-        subtitle="Your emotional landscape at a glance"
+        subtitle="Your luminous landscape gathered in one glance"
       >
         {error && (
           <p className="rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm font-semibold text-rose-600">
@@ -181,9 +181,9 @@ function JournalerDashboard() {
         {dashboard ? (
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             <MetricCard
-              title="Reflection streak"
+              title="Reflection rings"
               value={`${dashboard.streak || 0} days`}
-              description="How many consecutive days you've checked in."
+              description="Consecutive days you've whispered into your journal."
             />
             <MetricCard
               title="Average mood"
@@ -193,11 +193,11 @@ function JournalerDashboard() {
             <MetricCard
               title="Weekly rhythm"
               value={`${dashboard.stats?.consistency || 0} entries / week`}
-              description="Keep showing up—tiny notes become growth rings."
+              description="Return often—small notes become the rings of your tree."
             />
           </div>
         ) : (
-          <p className={emptyStateClasses}>Submit an entry to unlock insights.</p>
+          <p className={emptyStateClasses}>Offer today’s reflection to awaken your insights.</p>
         )}
       </SectionCard>
 
@@ -231,8 +231,8 @@ function JournalerDashboard() {
 
         <div className="flex flex-col gap-6">
           <SectionCard
-            title="Mood trend"
-            subtitle="Last reflections in a glance"
+            title="Mood constellations"
+            subtitle="Recent reflections traced across time"
             action={
               <select
                 className={`${selectCompactClasses} w-full md:w-40`}
@@ -253,60 +253,57 @@ function JournalerDashboard() {
                 <MoodTrendChart data={filteredMoodTrend} />
               ) : (
                 <p className={emptyStateClasses}>
-                  No mood entries in this timeframe yet. Try a different filter to review
-                  earlier reflections.
+                  No moods appear in this window yet. Try another filter to revisit earlier constellations.
                 </p>
               )
             ) : (
               <p className={emptyStateClasses}>
-                The chart grows after your first few entries.
+                The chart will glow once your first few entries take root.
               </p>
             )}
           </SectionCard>
 
           <SectionCard
             title="Sleep quality"
-            subtitle="Log how you slept each day to observe restorative patterns."
+            subtitle="Log your rest each day to notice restorative tides."
           >
             {dashboard?.sleepTrend?.length ? (
               filteredSleepTrend.length ? (
                 <MoodTrendChart data={filteredSleepTrend} />
               ) : (
                 <p className={emptyStateClasses}>
-                  No sleep entries in this timeframe yet. Try a different filter to review earlier
-                  rest notes.
+                  No rest notes live in this window yet. Adjust the filter to revisit earlier dreams.
                 </p>
               )
             ) : (
               <p className={emptyStateClasses}>
-                Track your rest by adding sleep quality when you journal.
+                Invite rest into view by noting sleep quality as you journal.
               </p>
             )}
           </SectionCard>
 
           <SectionCard
-            title="Energy level"
-            subtitle="Capture how energized you feel to spot ebb-and-flow trends."
+            title="Energy tide"
+            subtitle="Capture how your spark rises and softens over time."
           >
             {dashboard?.energyTrend?.length ? (
               filteredEnergyTrend.length ? (
                 <MoodTrendChart data={filteredEnergyTrend} />
               ) : (
                 <p className={emptyStateClasses}>
-                  No energy entries in this timeframe yet. Try a different filter to explore earlier
-                  check-ins.
+                  No energy notes appear in this window. Adjust the filter to explore earlier currents.
                 </p>
               )
             ) : (
               <p className={emptyStateClasses}>
-                Note your energy levels in the form to unlock this insight.
+                Record your energy in each form to awaken this insight.
               </p>
             )}
           </SectionCard>
         </div>
       </div>
 
-      <SectionCard title="Recent entries" subtitle="Revisit your notes and growth moments">
+      <SectionCard title="Recent entries" subtitle="Revisit the notes and growth rings you’ve gathered">
         {filteredEntries.length ? (
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {filteredEntries.slice(0, 6).map((entry) => (
@@ -351,8 +348,8 @@ function JournalerDashboard() {
         ) : (
           <p className={emptyStateClasses}>
             {entries.length
-              ? "No entries in this timeframe yet. Adjust the filter to revisit earlier notes."
-              : "Your journal is waiting. Capture today's mood to begin your tree-ring."}
+              ? "No entries shine in this window yet. Adjust the filter to revisit earlier notes."
+              : "Your journal is waiting. Capture today’s mood to grow your first ring."}
           </p>
         )}
       </SectionCard>

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -20,28 +20,27 @@ function LandingPage() {
           <div
             className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
           >
-            🌿 Grow whole
+            🌿 Luminous practice
           </div>
           <h1 className={`${displayTextClasses} text-emerald-950`}>
-            Grow whole, not in fragments.
+            Let your inner canopy breathe in one rhythm.
           </h1>
           <p className={`${leadTextClasses} text-emerald-900/80`}>
-            Aleya weaves journaling, mentorship, and gentle accountability so you can
-            notice your emotions, nurture your habits, and share progress with the
-            guides who support you.
+            Aleya braids reflection, companionship, and gentle accountability so each
+            note of care, habit, and rest can bloom together beneath a steady light.
           </p>
           <div className="flex flex-wrap gap-4">
             <Link
               className={`${primaryButtonClasses} px-6 py-3 text-base`}
               to="/register"
             >
-              Start journaling
+              Begin your Aleya journal
             </Link>
             <Link
               className={`${secondaryButtonClasses} px-6 py-3 text-base`}
               to="/login"
             >
-              I already have an account
+              Return to my Aleya grove
             </Link>
           </div>
         </div>
@@ -49,23 +48,23 @@ function LandingPage() {
           <div className="overflow-hidden rounded-3xl border border-emerald-200 text-white shadow-lg shadow-emerald-900/10">
             <div className="grid text-left">
               <TreeLayer
-                title="Roots · Self-care"
-                description="Food, movement, and rest sustain growth."
+                title="Roots · Self-tending"
+                description="Nourish your soil with rest, movement, and sustenance."
                 className="bg-emerald-900"
               />
               <TreeLayer
-                title="Trunk · Purpose"
-                description="Strength comes from purpose, simplicity, and stability."
+                title="Trunk · Steady purpose"
+                description="Anchor into clarity, simplicity, and the strength to stay."
                 className="bg-emerald-700"
               />
               <TreeLayer
-                title="Branches · Learning & Relationships"
-                description="Growth means reaching, learning, and connecting."
+                title="Branches · Learning & kinship"
+                description="Reach outward to learn, listen, and weave resilient bonds."
                 className="bg-teal-600"
               />
               <TreeLayer
-                title="Fruit · Creative Expression"
-                description="Creativity and legacy are the gifts we leave behind."
+                title="Fruit · Creative offering"
+                description="Share the stories and legacies that ripen from your tending."
                 className="bg-amber-600"
               />
             </div>
@@ -76,25 +75,25 @@ function LandingPage() {
       <section className="grid gap-6 md:grid-cols-3">
         <FeatureCard
           title="Journalers"
-          description="Build a meaningful check-in ritual, track your mood, and celebrate streaks with visual dashboards."
+          description="Craft a ritual of arrival, trace your moods like constellations, and celebrate the rings of practice you grow."
         />
         <FeatureCard
           title="Mentors"
-          description="Receive summaries when mentees share entries, assign tailored prompts, and spot low-mood patterns quickly."
+          description="Receive gentle digests when mentees share, offer bespoke prompts, and notice when their light softens."
         />
         <FeatureCard
           title="Administrators"
-          description="Configure journeys, manage forms, and steward a secure space where wellbeing data stays protected."
+          description="Shape guided journeys, tend the form library, and protect the sanctuary where every reflection is held."
         />
       </section>
 
       <section className="rounded-3xl bg-emerald-600 px-8 py-10 text-white shadow-xl shadow-emerald-900/20">
         <h2 className={`${largeHeadingClasses} tracking-tight`}>
-          Your day is a living ecosystem.
+          Each day is a breathing grove.
         </h2>
         <p className={`mt-4 ${leadTextClasses} text-white/80`}>
-          Aleya keeps the ecosystem connected—so when you tend to sleep, learning,
-          relationships, and creative sparks, you can see the whole tree flourish.
+          Aleya keeps every rootline connected—so when you tend sleep, learning,
+          kinship, and creative sparks, you witness the whole canopy awaken.
         </p>
       </section>
     </div>

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -43,30 +43,32 @@ function LoginPage() {
           <span
             className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
           >
-            🌿 Welcome back
+            🌿 Returning to the grove
           </span>
           <h1 className={`${displayTextClasses} text-emerald-950`}>
-            Welcome back
+            Welcome back to your luminous grove.
           </h1>
           <p className={`${leadTextClasses} text-emerald-900/80`}>
-            Continue tending your growth journey. Sign in to pick up where you
-            left off.
+            Continue tending the practice you planted. Step inside to gather
+            yesterday's wisdom and set intention for today.
           </p>
           <div className="grid gap-4 rounded-3xl border border-emerald-100 bg-white/70 p-6 shadow-inner shadow-emerald-900/5 sm:grid-cols-2">
             <div className="space-y-1">
               <p className={`${bodySmallStrongTextClasses} text-emerald-800`}>
-                Track momentum
+                Trace your rhythm
               </p>
               <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
-                Review your reflections and notice the progress you are making.
+                Revisit your reflections and witness how each note becomes a
+                new ring of growth.
               </p>
             </div>
             <div className="space-y-1">
               <p className={`${bodySmallStrongTextClasses} text-emerald-800`}>
-                Stay connected
+                Stay entwined
               </p>
               <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
-                Message mentors, respond to prompts, and nurture your practice.
+                Share with mentors, respond to gentle prompts, and let your
+                practice stay companioned.
               </p>
             </div>
           </div>
@@ -74,10 +76,11 @@ function LoginPage() {
         <div className="rounded-3xl border border-emerald-100 bg-white/80 p-8 shadow-2xl shadow-emerald-900/10 backdrop-blur md:p-10">
           <div className="mb-8 space-y-2 text-center">
             <p className={`${eyebrowTextClasses} text-emerald-600`}>
-              Sign in to your account
+              Step back into Aleya
             </p>
             <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
-              Enter your credentials to continue exploring Aleya.
+              Enter your credentials to reopen the pathways you’ve been
+              tending.
             </p>
           </div>
           <form className="space-y-5" onSubmit={handleSubmit}>
@@ -125,7 +128,7 @@ function LoginPage() {
               to="/register"
               className="font-semibold text-emerald-700 transition hover:text-emerald-600"
             >
-              Create an account
+              Plant your account
             </Link>
           </p>
         </div>

--- a/frontend/src/pages/MentorDashboard.js
+++ b/frontend/src/pages/MentorDashboard.js
@@ -69,14 +69,14 @@ function MentorDashboard() {
   };
 
   if (loading && !dashboard) {
-    return <LoadingState label="Loading mentor dashboard" />;
+    return <LoadingState label="Illuminating your mentor canopy" />;
   }
 
   return (
     <div className="flex w-full flex-1 flex-col gap-8">
       <SectionCard
-        title="Mentor overview"
-        subtitle="Encourage consistency and spot tender seasons quickly"
+        title="Mentor constellation"
+        subtitle="Encourage steady practice and notice tender seasons quickly"
       >
         {error && (
           <p className="rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 text-sm font-semibold text-rose-600">
@@ -88,29 +88,29 @@ function MentorDashboard() {
             <MetricCard
               title="Active mentees"
               value={dashboard.overview?.menteeCount || 0}
-              description="Number of journalers currently linked with you."
+              description="Journalers currently linked beneath your guidance."
             />
             <MetricCard
-              title="Pending requests"
+              title="Pending invitations"
               value={dashboard.overview?.pendingRequests || 0}
-              description="People waiting for your response."
+              description="People waiting for your welcome."
             />
             <MetricCard
               title="Unread updates"
               value={dashboard.overview?.unreadNotifications || 0}
-              description="Entries shared with you that need a review."
+              description="Shared reflections ready for your care."
             />
           </div>
         ) : (
           <p className={emptyStateClasses}>
-            Link with a journaler to begin mentoring.
+            Link with a journaler to begin weaving this constellation.
           </p>
         )}
       </SectionCard>
 
       <SectionCard
-        title="Incoming mentorship requests"
-        subtitle="Review invitations and accept when it’s a good fit"
+        title="Incoming mentorship invitations"
+        subtitle="Review each invitation and respond when the timing feels right"
       >
         <MentorRequestList
           requests={requests}
@@ -123,7 +123,7 @@ function MentorDashboard() {
 
       <SectionCard
         title="Mentees"
-        subtitle="Recent reflections shared with you"
+        subtitle="Recent reflections your mentees have shared"
       >
         {dashboard?.mentees?.length ? (
           <div className="grid gap-4 lg:grid-cols-2">
@@ -141,7 +141,7 @@ function MentorDashboard() {
                 {mentee.trend?.length ? (
                   <MoodTrendChart data={mentee.trend} />
                 ) : (
-                  <p className={emptyStateClasses}>No shared entries yet.</p>
+                  <p className={emptyStateClasses}>No shared entries yet—invite them to share when ready.</p>
                 )}
                 {mentee.alerts?.lowMood?.length > 0 && (
                   <div className="rounded-2xl border-l-4 border-amber-400 bg-amber-50/80 p-4">
@@ -185,13 +185,13 @@ function MentorDashboard() {
             ))}
           </div>
         ) : (
-          <p className={emptyStateClasses}>No mentees yet. Accept a request to begin.</p>
+          <p className={emptyStateClasses}>No mentees yet. Accept a request to begin weaving together.</p>
         )}
       </SectionCard>
 
       <SectionCard
         title="Notifications"
-        subtitle="Entries shared with you based on mentee privacy settings"
+        subtitle="Entries shared with you according to each mentee’s privacy"
       >
         <NotificationList
           notifications={notifications}

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -108,7 +108,7 @@ function RegisterPage() {
         setSubmittedEmail((form.email || "").trim());
         setMentorApprovalMessage(
           err?.message ||
-            "Thanks for your interest in mentoring. We'll email you once an administrator approves your application."
+            "Thank you for offering your guidance. We'll email you as soon as an administrator lights the green lantern of approval."
         );
         setMentorApplicationSubmitted(true);
         setLocalError(null);
@@ -133,14 +133,14 @@ function RegisterPage() {
             <span className="text-3xl">🌿</span>
           </div>
           <h1 className={`${displayTextClasses} text-emerald-900`}>
-            Mentor application received
+            Your mentor lantern is on its way
           </h1>
           <p className={`mt-4 ${leadTextClasses} text-emerald-900/80`}>
             {mentorApprovalMessage}
           </p>
           {submittedEmail && (
             <p className={`mt-3 ${bodySmallMutedTextClasses} text-emerald-900/70`}>
-              We'll reach out at <span className="font-semibold">{submittedEmail}</span> once a decision has been made.
+              We'll reach out at <span className="font-semibold">{submittedEmail}</span> as soon as an administrator completes the welcome.
             </p>
           )}
           <button
@@ -151,7 +151,7 @@ function RegisterPage() {
             }}
             className={`mt-8 inline-flex items-center justify-center gap-2 ${primaryButtonClasses}`}
           >
-            Return to registration
+            Return to the form
           </button>
         </div>
       </div>
@@ -173,10 +173,12 @@ function RegisterPage() {
           <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-600">
             <span className="text-3xl">✉️</span>
           </div>
-          <h1 className={`${displayTextClasses} text-emerald-900`}>Check your inbox</h1>
+          <h1 className={`${displayTextClasses} text-emerald-900`}>
+            Watch for the Aleya lantern
+          </h1>
           <p className={`mt-4 ${leadTextClasses} text-emerald-900/80`}>
-            We've sent a verification link to {submittedEmail || "your email"}.
-            Follow the link to activate your account.
+            We've sent a verification link to {submittedEmail || "your email"} so
+            you can kindle your new account. Follow the glow to finish arriving.
           </p>
           {verificationDetails?.message && (
             <p
@@ -187,8 +189,8 @@ function RegisterPage() {
           )}
           {expiresCopy && (
             <p className={`mt-3 ${bodySmallMutedTextClasses} text-emerald-900/70`}>
-              The link will expire {expiresCopy}. If it doesn't arrive within a
-              few minutes, check your spam or junk folder.
+              The link will fade {expiresCopy}. If it doesn't appear soon, peek in
+              your spam or junk folders.
             </p>
           )}
           <Link
@@ -209,14 +211,15 @@ function RegisterPage() {
           <span
             className={`inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-white/80 px-4 py-2 shadow-sm shadow-emerald-900/5 ${bodySmallStrongTextClasses} text-emerald-700`}
           >
-            🌱 New to Aleya
+            🌱 Arriving at Aleya
           </span>
           <h1 className={`${displayTextClasses} text-emerald-950`}>
-            Join Aleya
+            Begin your luminous account
           </h1>
           <p className={`${leadTextClasses} text-emerald-900/80`}>
-            Create an account to start journaling, mentor others, or steward the
-            platform. Your journey toward mindful growth begins here.
+            Plant your name in Aleya to journal with intention, offer your wisdom,
+            or steward the sanctuary for others. This is the first ring of your new
+            practice.
           </p>
           <div className="grid gap-4 rounded-3xl border border-emerald-100 bg-white/70 p-6 shadow-inner shadow-emerald-900/5 sm:grid-cols-2">
             <div className="space-y-1">
@@ -224,7 +227,8 @@ function RegisterPage() {
                 Journalers
               </p>
               <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
-                Reflect with guided prompts and track meaningful insights.
+                Reflect with guided prompts and gather the insights that shimmer
+                through your days.
               </p>
             </div>
             <div className="space-y-1">
@@ -232,7 +236,8 @@ function RegisterPage() {
                 Mentors
               </p>
               <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
-                Share your wisdom, set your availability, and support others.
+                Share your wisdom, set gentle rhythms, and support others as they
+                unfurl.
               </p>
             </div>
           </div>
@@ -240,10 +245,11 @@ function RegisterPage() {
         <div className="rounded-3xl border border-emerald-100 bg-white/80 p-8 shadow-2xl shadow-emerald-900/10 backdrop-blur md:p-10">
           <div className="mb-8 space-y-2 text-center">
             <p className={`${eyebrowTextClasses} text-emerald-600`}>
-              Create your account
+              Shape your presence
             </p>
             <p className={`${bodySmallMutedTextClasses} text-emerald-900/70`}>
-              Fill in the details to unlock journaling and mentoring tools.
+              Share a few details to unlock Aleya’s journals, mentorship, and
+              stewardship tools.
             </p>
           </div>
           <form className="space-y-5" onSubmit={handleSubmit}>
@@ -316,8 +322,8 @@ function RegisterPage() {
               <p
                 className={`-mt-2 rounded-2xl border border-emerald-100 bg-emerald-50/60 px-4 py-3 ${bodySmallMutedTextClasses} text-emerald-900/70`}
               >
-                Mentor accounts require administrator approval. Submit your
-                application below and we'll notify you when it's accepted.
+                Mentor accounts require an administrator’s blessing. Submit your
+                application below and we’ll send word when the invitation is lit.
               </p>
             )}
             <label className={`block ${formLabelClasses}`}>
@@ -358,7 +364,7 @@ function RegisterPage() {
                     value={form.mentorProfile.availability}
                     onChange={handleMentorChange}
                     className={inputClasses}
-                    placeholder="Share your availability"
+                    placeholder="Share when you can hold space"
                   />
                 </label>
                 <label className={`block ${formLabelClasses}`}>
@@ -370,9 +376,9 @@ function RegisterPage() {
                     onChange={handleMentorChange}
                     className={`${textareaClasses} resize-none`}
                     placeholder="Introduce yourself to potential journalers"
-                  />
-                </label>
-              </div>
+                />
+              </label>
+            </div>
             )}
 
             {(localError || error) && (
@@ -385,16 +391,16 @@ function RegisterPage() {
               className={`${primaryButtonClasses} w-full`}
               disabled={loading}
             >
-              {loading ? "Creating account..." : "Create account"}
+              {loading ? "Rooting your account..." : "Create luminous account"}
             </button>
           </form>
           <p className={`mt-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}>
-            Already have an account?{" "}
+            Already tending a space?{" "}
             <Link
               to="/login"
               className="font-semibold text-emerald-700 transition hover:text-emerald-600"
             >
-              Sign in
+              Step inside
             </Link>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- weave Aleya's poetic grove voice through landing, auth, dashboards, notifications, and SOS copy
- tune shared helpers like LoadingState, JournalEntryForm, and mentor request labels to match the new theme
- document the tone guidance in frontend/AGENTS.md and note the copy refresh in docs/Wiki.md

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cb7900b22483339bcb967305ae7c43