### PR TITLE
Remove administrator role highlight from landing page

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -29,3 +29,7 @@
 - Rewrote major frontend copy (landing, authentication, dashboards, notifications, SOS modal) with Aleya’s poetic grove tone so the experience feels consistently luminous and nature-infused.
 - Updated `frontend/AGENTS.md` to note the new copy voice guidance for future contributors.
 
+# 2025-09-23
+- Removed the landing page administrator feature card and tightened the feature grid to two columns so only journalers and mentors are highlighted.
+- Extended `frontend/AGENTS.md` with a note about keeping the landing feature cards balanced across breakpoints.
+

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -10,6 +10,8 @@
 - When composing new components, import the relevant constants from `src/styles/ui.js` instead of hard-coding class strings. This keeps the font stack and sizing consistent across the app.
 - Update this document if you introduce new design tokens so future changes remain consistent.
 - When updating copy, honor Aleya’s luminous grove tone: poetic, gentle, and nature-infused while keeping guidance clear.
+- Landing page role highlights currently center Journalers and Mentors; retire or add feature cards thoughtfully so the grid s
+tays balanced across breakpoints.
 - For modal overlays, center panels with `fixed inset-0 flex min-h-screen items-center justify-center` and wrap the panel
   content in a scrollable container (e.g. `max-h-[min(85vh,40rem)] overflow-y-auto`) so longer forms remain visible on smaller
   screens.

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -72,7 +72,7 @@ function LandingPage() {
         </div>
       </section>
 
-      <section className="grid gap-6 md:grid-cols-3">
+      <section className="grid gap-6 md:grid-cols-2">
         <FeatureCard
           title="Journalers"
           description="Craft a ritual of arrival, trace your moods like constellations, and celebrate the rings of practice you grow."
@@ -80,10 +80,6 @@ function LandingPage() {
         <FeatureCard
           title="Mentors"
           description="Receive gentle digests when mentees share, offer bespoke prompts, and notice when their light softens."
-        />
-        <FeatureCard
-          title="Administrators"
-          description="Shape guided journeys, tend the form library, and protect the sanctuary where every reflection is held."
         />
       </section>
 


### PR DESCRIPTION
## Summary
- remove the administrator feature card from the landing page and rebalance the grid layout for the remaining roles
- refresh frontend guidance so landing feature cards stay visually balanced across breakpoints
- record the landing page update in the repository wiki

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb7caa4f648333b5a40ec78fd3ae5c