### PR TITLE
Fix SOS modal markup and restore muted text token

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -32,4 +32,5 @@
 # 2025-09-23
 - Removed the landing page administrator feature card and tightened the feature grid to two columns so only journalers and mentors are highlighted.
 - Extended `frontend/AGENTS.md` with a note about keeping the landing feature cards balanced across breakpoints.
+- Restored the SOS modal header structure in `frontend/src/components/PanicButton.js` so the close button sits inside the header flex row, preventing mismatched JSX tags, refreshed `frontend/src/styles/ui.js` with a `bodySmallMutedTextClasses` alias for the muted small text token, and updated `frontend/AGENTS.md` with the guidance to keep header content wrapped together.
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,3 +17,5 @@ tays balanced across breakpoints.
   screens.
 - Pair destructive or primary modal actions with a secondary "Cancel" control that uses `btn-secondary` so people always have
   a clear escape hatch.
+- Keep modal headers in a single flex container that houses both the title block and the close button so the markup stays
+  balanced and easier to maintain.

--- a/frontend/src/components/PanicButton.js
+++ b/frontend/src/components/PanicButton.js
@@ -144,94 +144,95 @@ function PanicButton() {
                     Choose a linked mentor and share why you need immediate care so they can arrive prepared.
                   </p>
                 </div>
-              <button
-                type="button"
-                className={`${secondaryButtonClasses} px-4 py-2 text-sm`}
-                onClick={closeDialog}
-              >
-                Close
-              </button>
-            </div>
+                <button
+                  type="button"
+                  className={`${secondaryButtonClasses} px-4 py-2 text-sm`}
+                  onClick={closeDialog}
+                >
+                  Close
+                </button>
+              </div>
 
-            <div className="mt-6 space-y-4">
-              {loading && (
-                <p className={bodySmallMutedTextClasses}>Calling your mentors…</p>
-              )}
+              <div className="mt-6 space-y-4">
+                {loading && (
+                  <p className={bodySmallMutedTextClasses}>Calling your mentors…</p>
+                )}
 
-              {!loading && !hasContacts && !error && (
-                <p className={bodySmallMutedTextClasses}>
-                  You are not yet linked with mentors. Invite one to activate this SOS lantern.
-                </p>
-              )}
+                {!loading && !hasContacts && !error && (
+                  <p className={bodySmallMutedTextClasses}>
+                    You are not yet linked with mentors. Invite one to activate this SOS lantern.
+                  </p>
+                )}
 
-              {hasContacts && (
-                <form className="space-y-5" onSubmit={handleSubmit}>
-                  <div className="space-y-2">
-                    <label className={bodySmallStrongTextClasses} htmlFor="sos-mentor">
-                      Reach out to
-                    </label>
-                    <select
-                      id="sos-mentor"
-                      className={selectCompactClasses}
-                      value={selectedMentor}
-                      onChange={(event) => setSelectedMentor(event.target.value)}
-                      disabled={sending}
-                    >
-                      <option value="">Select a mentor</option>
-                      {contacts.map((contact) => (
-                        <option key={contact.id} value={contact.id}>
-                          {contact.name || contact.email}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                {hasContacts && (
+                  <form className="space-y-5" onSubmit={handleSubmit}>
+                    <div className="space-y-2">
+                      <label className={bodySmallStrongTextClasses} htmlFor="sos-mentor">
+                        Reach out to
+                      </label>
+                      <select
+                        id="sos-mentor"
+                        className={selectCompactClasses}
+                        value={selectedMentor}
+                        onChange={(event) => setSelectedMentor(event.target.value)}
+                        disabled={sending}
+                      >
+                        <option value="">Select a mentor</option>
+                        {contacts.map((contact) => (
+                          <option key={contact.id} value={contact.id}>
+                            {contact.name || contact.email}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
 
-                  <div className="space-y-2">
-                    <label className={bodySmallStrongTextClasses} htmlFor="sos-message">
-                      What do they need to know?
-                    </label>
-                    <textarea
-                      id="sos-message"
-                      className={textareaClasses}
-                      rows={4}
-                      placeholder="Share context so they can meet you right away."
-                      value={message}
-                      onChange={(event) => setMessage(event.target.value)}
-                      disabled={sending}
-                    />
-                  </div>
+                    <div className="space-y-2">
+                      <label className={bodySmallStrongTextClasses} htmlFor="sos-message">
+                        What do they need to know?
+                      </label>
+                      <textarea
+                        id="sos-message"
+                        className={textareaClasses}
+                        rows={4}
+                        placeholder="Share context so they can meet you right away."
+                        value={message}
+                        onChange={(event) => setMessage(event.target.value)}
+                        disabled={sending}
+                      />
+                    </div>
 
-                  {error && (
-                    <p className="text-sm text-rose-600">{error}</p>
-                  )}
+                    {error && (
+                      <p className="text-sm text-rose-600">{error}</p>
+                    )}
 
-                  {success && (
-                    <p className="text-sm text-emerald-600">{success}</p>
-                  )}
+                    {success && (
+                      <p className="text-sm text-emerald-600">{success}</p>
+                    )}
 
-                  <div className="flex justify-end gap-3">
-                    <button
-                      type="button"
-                      className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
-                      onClick={closeDialog}
-                      disabled={sending}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className={`${dangerButtonClasses} px-5 py-2.5 text-sm`}
-                      disabled={sending}
-                    >
-                      {sending ? "Sending…" : "Send SOS lantern"}
-                    </button>
-                  </div>
-                </form>
-              )}
+                    <div className="flex justify-end gap-3">
+                      <button
+                        type="button"
+                        className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                        onClick={closeDialog}
+                        disabled={sending}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="submit"
+                        className={`${dangerButtonClasses} px-5 py-2.5 text-sm`}
+                        disabled={sending}
+                      >
+                        {sending ? "Sending…" : "Send SOS lantern"}
+                      </button>
+                    </div>
+                  </form>
+                )}
 
-              {error && !hasContacts && (
-                <p className="text-sm text-rose-600">{error}</p>
-              )}
+                {error && !hasContacts && (
+                  <p className="text-sm text-rose-600">{error}</p>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/styles/ui.js
+++ b/frontend/src/styles/ui.js
@@ -33,6 +33,7 @@ export const leadTextClasses = "text-body-lg";
 export const bodyTextClasses = "text-body";
 export const bodySmallTextClasses = "text-body-sm";
 export const bodySmallStrongTextClasses = "text-body-sm-strong";
+export const bodySmallMutedTextClasses = "text-muted";
 export const eyebrowTextClasses = "text-eyebrow";
 export const captionTextClasses = "text-caption";
 export const formLabelClasses = "form-label";


### PR DESCRIPTION
## Summary
- move the Panic SOS modal close button back inside the header flex row so the JSX closes cleanly and keeps the layout balanced
- note the modal-header guidance in `frontend/AGENTS.md` and restore the `bodySmallMutedTextClasses` export that maps to the muted text token
- document the fix and token export in `docs/Wiki.md`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe3b361188333910fa0ec50e9fc0f