### PR TITLE
Add admin form deletion endpoint

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -4,3 +4,5 @@
 - Keep mentor panic alert flows consistent with mentor escalation requirements and ensure new middleware is added as individual arguments instead of wrapped arrays when Express parsing causes issues.
 - Document all backend changes in `docs/Wiki.md` so future contributors understand the context behind updates.
 - Double-check route definitions end with their closing `);` pair so `node --check` passes before pushing changes.
+- When touching the admin form management endpoints, keep the default template protections intact so system templates are never
+  deleted by mistake.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# 2025-09-24
+- Added an admin-only DELETE `/admin/forms/:id` route that blocks removal of default templates while allowing admins to prune
+  mentee-created forms and automatically clear their assignments.
+- Noted in `backend/AGENTS.md` that default templates should remain protected when adjusting admin form management logic.
+
 # 2025-09-21
 - Added a secondary cancel action to the SOS modal in `frontend/src/components/PanicButton.js` using the shared `btn-secondary`
   token so people can close the dialog without reaching the header button.


### PR DESCRIPTION
## Summary
- add an admin-only DELETE /admin/forms/:id endpoint that protects default templates while removing mentee-created forms and their links
- document the new route in docs/Wiki.md and remind backend contributors to keep default templates safe in backend/AGENTS.md

## Testing
- node --check backend/routes/admin.js

------
https://chatgpt.com/codex/tasks/task_e_68cc07a7d95083338f6c8c4af3bc0d57