### PR TITLE
Restrict admin form creation and enrich management tools

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -6,3 +6,7 @@
 - Double-check route definitions end with their closing `);` pair so `node --check` passes before pushing changes.
 - When touching the admin form management endpoints, keep the default template protections intact so system templates are never
   deleted by mistake.
+- Admin `/forms` responses must continue returning `creatorName` metadata and the `mentees` association array so the frontend can
+  surface who built each form and which journalers are linked.
+- Leave the `/forms` creation route restricted to mentors; admins now manage forms without crafting new templates through that
+  endpoint.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# 2025-09-25
+- Restricted `/forms` creation to mentors, enriched the admin `/forms` listing with creator names and mentee associations, and
+  refreshed the Forms page so admins manage existing templates with filters, assignment removal, and delete controls instead of
+  crafting new forms.
+
 # 2025-09-24
 - Added an admin-only DELETE `/admin/forms/:id` route that blocks removal of default templates while allowing admins to prune
   mentee-created forms and automatically clear their assignments.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -21,3 +21,5 @@ tays balanced across breakpoints.
   balanced and easier to maintain.
 - Admins view a pared-down settings experience: hide mentor notification controls, the weekly summary toggle, profile submit
   actions, and the data export/deletion tools whenever `user.role === "admin"`.
+- In the Forms builder page, keep the admin view focused on stewardship: do not reintroduce the creation UI for admins, preserve
+  the filter controls, and ensure the mentee association list stays actionable with the existing remove affordance.

--- a/frontend/src/pages/FormBuilderPage.js
+++ b/frontend/src/pages/FormBuilderPage.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import apiClient from "../api/client";
 import LoadingState from "../components/LoadingState";
 import SectionCard from "../components/SectionCard";
@@ -6,13 +6,16 @@ import { useAuth } from "../context/AuthContext";
 import {
   checkboxClasses,
   chipBaseClasses,
+  dangerButtonClasses,
   emptyStateClasses,
   infoTextClasses,
   inputClasses,
   inputCompactClasses,
+  mutedTextClasses,
   primaryButtonClasses,
   secondaryButtonClasses,
   selectCompactClasses,
+  subtleButtonClasses,
   textareaClasses,
 } from "../styles/ui";
 
@@ -35,6 +38,11 @@ function FormBuilderPage() {
     fields: [createField()],
   });
   const [assignment, setAssignment] = useState({ menteeId: "", formId: "" });
+  const [searchTerm, setSearchTerm] = useState("");
+  const [visibilityFilter, setVisibilityFilter] = useState("all");
+  const [creatorFilter, setCreatorFilter] = useState("all");
+  const isAdmin = user.role === "admin";
+  const isMentor = user.role === "mentor";
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -58,6 +66,99 @@ function FormBuilderPage() {
     load();
   }, [load]);
 
+  const creatorOptions = useMemo(() => {
+    const names = new Set();
+
+    forms.forEach((form) => {
+      if (form.creatorName) {
+        names.add(form.creatorName);
+      }
+    });
+
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [forms]);
+
+  const filteredForms = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return forms.filter((form) => {
+      if (visibilityFilter !== "all" && form.visibility !== visibilityFilter) {
+        return false;
+      }
+
+      if (creatorFilter !== "all") {
+        const creatorName = form.creatorName || "";
+        if (!creatorName || creatorName !== creatorFilter) {
+          return false;
+        }
+      }
+
+      if (normalizedSearch) {
+        const searchSpace = [form.title, form.description];
+
+        if (Array.isArray(form.mentees)) {
+          form.mentees.forEach((mentee) => {
+            if (mentee?.name) {
+              searchSpace.push(mentee.name);
+            }
+          });
+        }
+
+        const haystack = searchSpace
+          .filter((value) => Boolean(value && value.length))
+          .join(" ")
+          .toLowerCase();
+
+        if (!haystack.includes(normalizedSearch)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [forms, searchTerm, visibilityFilter, creatorFilter]);
+
+  const filtersApplied =
+    searchTerm.trim().length > 0 ||
+    visibilityFilter !== "all" ||
+    creatorFilter !== "all";
+
+  const handleClearFilters = useCallback(() => {
+    setSearchTerm("");
+    setVisibilityFilter("all");
+    setCreatorFilter("all");
+  }, []);
+
+  const handleDeleteForm = useCallback(
+    async (formId) => {
+      if (!token) return;
+
+      try {
+        await apiClient.del(`/admin/forms/${formId}`, token);
+        await load();
+        setMessage("Form deleted successfully.");
+      } catch (err) {
+        setMessage(err.message);
+      }
+    },
+    [load, token]
+  );
+
+  const handleRemoveAssignment = useCallback(
+    async (formId, menteeId) => {
+      if (!token) return;
+
+      try {
+        await apiClient.del(`/forms/${formId}/assign/${menteeId}`, token);
+        await load();
+        setMessage("Mentee unassigned from form.");
+      } catch (err) {
+        setMessage(err.message);
+      }
+    },
+    [load, token]
+  );
+
   const handleFieldChange = (index, key, value) => {
     setFormDraft((prev) => {
       const updated = [...prev.fields];
@@ -79,21 +180,31 @@ function FormBuilderPage() {
 
   const handleCreateForm = async (event) => {
     event.preventDefault();
-    await apiClient.post("/forms", formDraft, token);
-    setMessage("Form created successfully.");
-    setFormDraft({ title: "", description: "", fields: [createField()] });
-    load();
+    try {
+      await apiClient.post("/forms", formDraft, token);
+      setFormDraft({ title: "", description: "", fields: [createField()] });
+      await load();
+      setMessage("Form created successfully.");
+    } catch (err) {
+      setMessage(err.message);
+    }
   };
 
   const assignForm = async (event) => {
     event.preventDefault();
     if (!assignment.menteeId || !assignment.formId) return;
-    await apiClient.post(
-      `/forms/${assignment.formId}/assign`,
-      { journalerId: Number(assignment.menteeId) },
-      token
-    );
-    setMessage("Form assigned to mentee.");
+    try {
+      await apiClient.post(
+        `/forms/${assignment.formId}/assign`,
+        { journalerId: Number(assignment.menteeId) },
+        token
+      );
+      await load();
+      setAssignment({ menteeId: "", formId: "" });
+      setMessage("Form assigned to mentee.");
+    } catch (err) {
+      setMessage(err.message);
+    }
   };
 
   if (loading) {
@@ -103,141 +214,143 @@ function FormBuilderPage() {
   return (
     <div className="flex w-full flex-1 flex-col gap-8">
       {message && <p className={infoTextClasses}>{message}</p>}
-      <SectionCard
-        title="Create a reflective form"
-        subtitle="Craft prompts that resonate with the people you support"
-      >
-        <form className="space-y-6" onSubmit={handleCreateForm}>
-          <label className="block text-sm font-semibold text-emerald-900/80">
-            Title
-            <input
-              type="text"
-              className={inputClasses}
-              value={formDraft.title}
-              onChange={(event) =>
-                setFormDraft((prev) => ({ ...prev, title: event.target.value }))
-              }
-              required
-            />
-          </label>
-          <label className="block text-sm font-semibold text-emerald-900/80">
-            Description
-            <textarea
-              className={textareaClasses}
-              value={formDraft.description}
-              onChange={(event) =>
-                setFormDraft((prev) => ({
-                  ...prev,
-                  description: event.target.value,
-                }))
-              }
-            />
-          </label>
+      {!isAdmin && (
+        <SectionCard
+          title="Create a reflective form"
+          subtitle="Craft prompts that resonate with the people you support"
+        >
+          <form className="space-y-6" onSubmit={handleCreateForm}>
+            <label className="block text-sm font-semibold text-emerald-900/80">
+              Title
+              <input
+                type="text"
+                className={inputClasses}
+                value={formDraft.title}
+                onChange={(event) =>
+                  setFormDraft((prev) => ({ ...prev, title: event.target.value }))
+                }
+                required
+              />
+            </label>
+            <label className="block text-sm font-semibold text-emerald-900/80">
+              Description
+              <textarea
+                className={textareaClasses}
+                value={formDraft.description}
+                onChange={(event) =>
+                  setFormDraft((prev) => ({
+                    ...prev,
+                    description: event.target.value,
+                  }))
+                }
+              />
+            </label>
 
-          {formDraft.fields.map((field, index) => (
-            <div
-              className="space-y-4 rounded-2xl border border-dashed border-emerald-200 bg-white/60 p-5"
-              key={index}
-            >
-              <div className="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]">
+            {formDraft.fields.map((field, index) => (
+              <div
+                className="space-y-4 rounded-2xl border border-dashed border-emerald-200 bg-white/60 p-5"
+                key={index}
+              >
+                <div className="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]">
+                  <label className="block text-sm font-semibold text-emerald-900/80">
+                    Label
+                    <input
+                      type="text"
+                      className={inputCompactClasses}
+                      value={field.label}
+                      onChange={(event) =>
+                        handleFieldChange(index, "label", event.target.value)
+                      }
+                      required
+                    />
+                  </label>
+                  <label className="block text-sm font-semibold text-emerald-900/80">
+                    Type
+                    <select
+                      className={selectCompactClasses}
+                      value={field.fieldType}
+                      onChange={(event) =>
+                        handleFieldChange(index, "fieldType", event.target.value)
+                      }
+                    >
+                      {FIELD_TYPES.map((type) => (
+                        <option key={type.value} value={type.value}>
+                          {type.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex items-center gap-2 text-sm font-semibold text-emerald-900/80">
+                    <input
+                      type="checkbox"
+                      className={checkboxClasses}
+                      checked={field.required}
+                      onChange={(event) =>
+                        handleFieldChange(index, "required", event.target.checked)
+                      }
+                    />
+                    Required
+                  </label>
+                </div>
                 <label className="block text-sm font-semibold text-emerald-900/80">
-                  Label
+                  Helper text
                   <input
                     type="text"
                     className={inputCompactClasses}
-                    value={field.label}
+                    value={field.helperText}
                     onChange={(event) =>
-                      handleFieldChange(index, "label", event.target.value)
+                      handleFieldChange(index, "helperText", event.target.value)
                     }
-                    required
                   />
                 </label>
-                <label className="block text-sm font-semibold text-emerald-900/80">
-                  Type
-                  <select
-                    className={selectCompactClasses}
-                    value={field.fieldType}
-                    onChange={(event) =>
-                      handleFieldChange(index, "fieldType", event.target.value)
-                    }
+                {field.fieldType === "select" && (
+                  <label className="block text-sm font-semibold text-emerald-900/80">
+                    Options (comma separated)
+                    <input
+                      type="text"
+                      className={inputCompactClasses}
+                      value={field.options.join(", ")}
+                      onChange={(event) =>
+                        handleFieldChange(
+                          index,
+                          "options",
+                          event.target
+                            .value.split(",")
+                            .map((opt) => opt.trim())
+                            .filter(Boolean)
+                        )
+                      }
+                    />
+                  </label>
+                )}
+                {formDraft.fields.length > 1 && (
+                  <button
+                    type="button"
+                    className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                    onClick={() => removeField(index)}
                   >
-                    {FIELD_TYPES.map((type) => (
-                      <option key={type.value} value={type.value}>
-                        {type.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label className="flex items-center gap-2 text-sm font-semibold text-emerald-900/80">
-                  <input
-                    type="checkbox"
-                    className={checkboxClasses}
-                    checked={field.required}
-                    onChange={(event) =>
-                      handleFieldChange(index, "required", event.target.checked)
-                    }
-                  />
-                  Required
-                </label>
+                    Remove field
+                  </button>
+                )}
               </div>
-              <label className="block text-sm font-semibold text-emerald-900/80">
-                Helper text
-                <input
-                  type="text"
-                  className={inputCompactClasses}
-                  value={field.helperText}
-                  onChange={(event) =>
-                    handleFieldChange(index, "helperText", event.target.value)
-                  }
-                />
-              </label>
-              {field.fieldType === "select" && (
-                <label className="block text-sm font-semibold text-emerald-900/80">
-                  Options (comma separated)
-                  <input
-                    type="text"
-                    className={inputCompactClasses}
-                    value={field.options.join(", ")}
-                    onChange={(event) =>
-                      handleFieldChange(
-                        index,
-                        "options",
-                        event.target
-                          .value.split(",")
-                          .map((opt) => opt.trim())
-                          .filter(Boolean)
-                      )
-                    }
-                  />
-                </label>
-              )}
-              {formDraft.fields.length > 1 && (
-                <button
-                  type="button"
-                  className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
-                  onClick={() => removeField(index)}
-                >
-                  Remove field
-                </button>
-              )}
+            ))}
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <button
+                type="button"
+                className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                onClick={addField}
+              >
+                Add another field
+              </button>
+              <button type="submit" className={`${primaryButtonClasses} w-full md:w-auto`}>
+                Save form
+              </button>
             </div>
-          ))}
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <button
-              type="button"
-              className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
-              onClick={addField}
-            >
-              Add another field
-            </button>
-            <button type="submit" className={`${primaryButtonClasses} w-full md:w-auto`}>
-              Save form
-            </button>
-          </div>
-        </form>
-      </SectionCard>
+          </form>
+        </SectionCard>
+      )}
 
-      {user.role === "mentor" && (
+      {isMentor && (
         <SectionCard
           title="Assign a form"
           subtitle="Give your mentees tailored prompts after the link is confirmed"
@@ -287,24 +400,125 @@ function FormBuilderPage() {
       )}
 
       <SectionCard title="Available forms" subtitle="See what journalers can access">
-        {forms.length ? (
+        {isAdmin && (
+          <div className="flex flex-wrap items-center gap-3 pb-4">
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search forms or mentees"
+              className={`${inputCompactClasses} w-full sm:w-64`}
+            />
+            <select
+              className={`${selectCompactClasses} w-full sm:w-44`}
+              value={visibilityFilter}
+              onChange={(event) => setVisibilityFilter(event.target.value)}
+            >
+              <option value="all">All visibility</option>
+              <option value="default">Default</option>
+              <option value="mentor">Mentor</option>
+              <option value="admin">Admin</option>
+            </select>
+            <select
+              className={`${selectCompactClasses} w-full sm:w-44`}
+              value={creatorFilter}
+              onChange={(event) => setCreatorFilter(event.target.value)}
+            >
+              <option value="all">All creators</option>
+              {creatorOptions.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className={`${subtleButtonClasses} px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60`}
+              onClick={handleClearFilters}
+              disabled={!filtersApplied}
+            >
+              Clear filters
+            </button>
+          </div>
+        )}
+
+        {filteredForms.length ? (
           <ul className="grid gap-4">
-            {forms.map((form) => (
-              <li
-                key={form.id}
-                className="flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-emerald-100 bg-white/70 p-5"
-              >
-                <div className="space-y-2">
-                  <p className="text-base font-semibold text-emerald-900">
-                    {form.title}
-                  </p>
-                  {form.description && (
-                    <p className="text-sm text-emerald-900/70">{form.description}</p>
+            {filteredForms.map((form) => {
+              const mentees = Array.isArray(form.mentees)
+                ? form.mentees.filter((mentee) => mentee && mentee.id)
+                : [];
+
+              return (
+                <li
+                  key={form.id}
+                  className="space-y-4 rounded-2xl border border-emerald-100 bg-white/70 p-5"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-2">
+                      <p className="text-base font-semibold text-emerald-900">
+                        {form.title}
+                      </p>
+                      {form.description && (
+                        <p className="text-sm text-emerald-900/70">{form.description}</p>
+                      )}
+                      {isAdmin && (
+                        <p className={`${mutedTextClasses} text-sm`}>
+                          Created by {form.creatorName || "Unknown creator"}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-col items-end gap-2">
+                      <span className={chipBaseClasses}>{form.visibility}</span>
+                      {isAdmin && (
+                        <>
+                          <button
+                            type="button"
+                            className={`${dangerButtonClasses} px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60`}
+                            disabled={form.is_default}
+                            onClick={() => handleDeleteForm(form.id)}
+                          >
+                            Delete form
+                          </button>
+                          {form.is_default && (
+                            <p className={`${mutedTextClasses} text-xs text-right`}>
+                              Default forms cannot be removed.
+                            </p>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  {isAdmin && (
+                    <div className="space-y-2 border-t border-emerald-100 pt-4">
+                      <p className="text-sm font-semibold text-emerald-900">
+                        Assigned mentees
+                      </p>
+                      {mentees.length ? (
+                        <ul className="flex flex-wrap gap-2">
+                          {mentees.map((mentee) => (
+                            <li key={mentee.id} className="flex items-center gap-2">
+                              <span className={chipBaseClasses}>{mentee.name}</span>
+                              <button
+                                type="button"
+                                className={`${subtleButtonClasses} px-3 py-1 text-xs`}
+                                onClick={() => handleRemoveAssignment(form.id, mentee.id)}
+                              >
+                                Remove
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className={`${mutedTextClasses} text-sm`}>
+                          No mentees linked yet.
+                        </p>
+                      )}
+                    </div>
                   )}
-                </div>
-                <span className={chipBaseClasses}>{form.visibility}</span>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <p className={emptyStateClasses}>No forms available yet.</p>


### PR DESCRIPTION
## Summary
- prevent admins from creating journal forms while enriching admin form listings with creator metadata and mentee associations
- refresh the Forms page so admins manage existing templates with filters, assignment removal, and delete controls instead of creating new forms
- document the admin stewardship expectations for form management in the backend/frontend agent notes and project wiki

## Testing
- node --check routes/forms.js

------
https://chatgpt.com/codex/tasks/task_e_68cc0db4d6748333a8eb7e99e1485b52