### PR TITLE
Add admin mentor management endpoints and UI

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -6,3 +6,5 @@
 - Double-check route definitions end with their closing `);` pair so `node --check` passes before pushing changes.
 - When touching the admin form management endpoints, keep the default template protections intact so system templates are never
   deleted by mistake.
+- Admin mentor management now includes routes for linking/unlinking journalers and deleting mentors; ensure mentor/journaler
+  integrity checks remain in place and update the wiki when adjusting these flows.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,10 @@
+# 2025-09-25
+- Added admin mentor management endpoints: `/admin/mentor-links` to link journalers, `/admin/mentor-links/:mentorId/:journalerId`
+  to sever connections, `/admin/journalers` for quick journaler lookups, and `/admin/mentors/:id` for removing mentor accounts
+  while returning `/admin/mentors` with detailed mentee listings.
+- Refreshed the admin mentorship page to focus on mentor stewardship by letting admins link mentees by email, review existing
+  relationships, and delete mentors directly from the cards.
+
 # 2025-09-24
 - Added an admin-only DELETE `/admin/forms/:id` route that blocks removal of default templates while allowing admins to prune
   mentee-created forms and automatically clear their assignments.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -21,3 +21,5 @@ tays balanced across breakpoints.
   balanced and easier to maintain.
 - Admins view a pared-down settings experience: hide mentor notification controls, the weekly summary toggle, profile submit
   actions, and the data export/deletion tools whenever `user.role === "admin"`.
+- Admin mentor management lives on `/mentorship`: show mentor cards with linked mentees, allow linking by email, and surface a
+  `Delete mentor` control using the shared button tokens so admins can curate relationships gracefully.


### PR DESCRIPTION
## Summary
- extend the admin mentor API with mentee details and add endpoints for linking/unlinking mentors, searching journalers, and deleting mentors
- refresh the admin mentorship screen so admins can link mentees by email, review connections, and delete mentors using shared button tokens
- document the mentor stewardship expectations in the AGENTS guides and wiki

## Testing
- node --check routes/admin.js

------
https://chatgpt.com/codex/tasks/task_e_68cc0f20ad408333bc021b20d799a55a