### PR TITLE
Add admin journaler management panel

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -8,6 +8,8 @@
   deleted by mistake.
 - Admin mentor management now includes routes for linking/unlinking journalers and deleting mentors; ensure mentor/journaler
   integrity checks remain in place and update the wiki when adjusting these flows.
+- Admin journaler stewardship now lists mentor relationships and allows deleting journaler accounts via `/admin/journalers` and
+  `DELETE /admin/journalers/:id`; keep the aggregated mentor metadata accurate and rely on cascading deletes for related data.
 - Admin `/forms` responses must continue returning `creatorName` metadata and the `mentees` association array so the frontend can
   surface who built each form and which journalers are linked.
 - Leave the `/forms` creation route restricted to mentors; admins now manage forms without crafting new templates through that

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# 2025-09-26
+- Extended the admin mentorship hub with a new Journaler management panel that lets admins search by name/email, review linked
+  mentors, unlink relationships, and delete journaler accounts. Backed the UI with enriched `/admin/journalers` data and a new
+  `DELETE /admin/journalers/:id` route so cascades clean up reflections, assignments, and links automatically.
+
 # 2025-09-25
 - Added admin mentor management endpoints: `/admin/mentor-links` to link journalers, `/admin/mentor-links/:mentorId/:journalerId`
   to sever connections, `/admin/journalers` for quick journaler lookups, and `/admin/mentors/:id` for removing mentor accounts

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -23,5 +23,7 @@ tays balanced across breakpoints.
   actions, and the data export/deletion tools whenever `user.role === "admin"`.
 - Admin mentor management lives on `/mentorship`: show mentor cards with linked mentees, allow linking by email, and surface a
   `Delete mentor` control using the shared button tokens so admins can curate relationships gracefully.
+- Admin journaler management also lives on `/mentorship`: surface a journaler list with linked mentors, include a search affordance,
+  and use the shared button tokens for unlinking mentors and deleting journaler accounts when an admin needs to retire access.
 - In the Forms builder page, keep the admin view focused on stewardship: do not reintroduce the creation UI for admins, preserve
   the filter controls, and ensure the mentee association list stays actionable with the existing remove affordance.

--- a/frontend/src/pages/MentorConnectionsPage.js
+++ b/frontend/src/pages/MentorConnectionsPage.js
@@ -26,7 +26,10 @@ function MentorConnectionsPage() {
   const [requests, setRequests] = useState([]);
   const [mentors, setMentors] = useState([]);
   const [mentees, setMentees] = useState([]);
+  const [journalers, setJournalers] = useState([]);
   const [search, setSearch] = useState("");
+  const [journalerSearch, setJournalerSearch] = useState("");
+  const [journalerQuery, setJournalerQuery] = useState("");
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState(null);
   const [selectedMentor, setSelectedMentor] = useState(null);
@@ -45,8 +48,17 @@ function MentorConnectionsPage() {
     setLoading(true);
     try {
       if (isAdmin) {
-        const mentorsRes = await apiClient.get("/admin/mentors", token);
+        const [mentorsRes, journalersRes] = await Promise.all([
+          apiClient.get("/admin/mentors", token),
+          apiClient.get(
+            `/admin/journalers${
+              journalerQuery ? `?q=${encodeURIComponent(journalerQuery)}` : ""
+            }`,
+            token
+          ),
+        ]);
         setMentors(mentorsRes.mentors || []);
+        setJournalers(journalersRes.journalers || []);
         setRequests([]);
         setMentees([]);
         setMessage(null);
@@ -72,13 +84,14 @@ function MentorConnectionsPage() {
         }
 
         setMessage(null);
+        setJournalers([]);
       }
     } catch (err) {
       setMessage(err.message);
     } finally {
       setLoading(false);
     }
-  }, [isAdmin, token, user.role]);
+  }, [isAdmin, journalerQuery, token, user.role]);
 
   useEffect(() => {
     load();
@@ -192,6 +205,29 @@ function MentorConnectionsPage() {
     }
   };
 
+  const handleJournalerSearch = async (event) => {
+    event.preventDefault();
+    setJournalerQuery(journalerSearch.trim().toLowerCase());
+  };
+
+  const deleteJournaler = async (journaler) => {
+    const confirmed = window.confirm(
+      `Remove ${journaler.name}? This will delete their reflections, assignments, and mentor links.`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await apiClient.del(`/admin/journalers/${journaler.id}`, token);
+      setMessage(`${journaler.name} has been removed.`);
+      await load();
+    } catch (error) {
+      setMessage(error.message);
+    }
+  };
+
   const handleNotificationRead = async (notificationId) => {
     if (!notificationsEnabled) {
       return;
@@ -208,6 +244,108 @@ function MentorConnectionsPage() {
     return (
       <div className="flex w-full flex-1 flex-col gap-8">
         {message && <p className={infoTextClasses}>{message}</p>}
+        <SectionCard
+          title="Journaler management"
+          subtitle="Shepherd every journaler's journey, review their mentor ties, and gently close accounts that need to rest"
+          action={
+            <form
+              className="flex flex-wrap items-center gap-3"
+              onSubmit={handleJournalerSearch}
+            >
+              <input
+                type="search"
+                placeholder="Search by name or email"
+                value={journalerSearch}
+                onChange={(event) => setJournalerSearch(event.target.value)}
+                className={`${inputCompactClasses} w-full sm:w-72`}
+              />
+              <button
+                type="submit"
+                className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+              >
+                Search journalers
+              </button>
+            </form>
+          }
+        >
+          {journalers.length ? (
+            <ul className="space-y-6">
+              {journalers.map((journaler) => {
+                const mentorList = Array.isArray(journaler.mentors)
+                  ? journaler.mentors
+                  : [];
+
+                return (
+                  <li
+                    key={journaler.id}
+                    className="rounded-2xl border border-emerald-100 bg-white/70 p-5"
+                  >
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="space-y-2">
+                        <p className="text-base font-semibold text-emerald-900">
+                          {journaler.name}
+                        </p>
+                        <p className={infoTextClasses}>{journaler.email}</p>
+                      </div>
+                      <div className="flex flex-col gap-3 lg:w-1/2">
+                        <div className="rounded-xl border border-emerald-100 bg-emerald-50/60 p-4">
+                          <p className={`${infoTextClasses} mb-3 font-semibold text-emerald-900`}>
+                            Linked mentors
+                          </p>
+                          {mentorList.length ? (
+                            <ul className="space-y-2">
+                              {mentorList.map((mentor) => (
+                                <li
+                                  key={mentor.id}
+                                  className="flex flex-col gap-2 rounded-lg bg-white/80 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                                >
+                                  <div>
+                                    <p className="text-sm font-semibold text-emerald-900">
+                                      {mentor.name || "Mentor"}
+                                    </p>
+                                    <p className={`${captionTextClasses} text-emerald-900/70`}>
+                                      {mentor.email}
+                                    </p>
+                                  </div>
+                                  <button
+                                    type="button"
+                                    className={`${secondaryButtonClasses} px-3 py-1 text-xs`}
+                                    onClick={() =>
+                                      unlinkMentee(mentor.id, {
+                                        id: journaler.id,
+                                        name: journaler.name,
+                                        email: journaler.email,
+                                      })
+                                    }
+                                  >
+                                    Unlink mentor
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className={infoTextClasses}>
+                              Not yet connected to a mentor.
+                            </p>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          className={`${dangerButtonClasses} self-start px-4 py-2 text-sm`}
+                          onClick={() => deleteJournaler(journaler)}
+                        >
+                          Delete journaler
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className={emptyStateClasses}>No journalers found.</p>
+          )}
+        </SectionCard>
         <SectionCard
           title="Mentor management"
           subtitle="Curate guides, connect them with journalers, and prune links that no longer serve"


### PR DESCRIPTION
## Summary
- enrich the admin journaler API with mentor relationship aggregation and a delete endpoint
- surface an admin-only journaler management panel with search, unlink, and delete controls alongside mentor stewardship
- document the new stewardship flow across the contributor guides and wiki

## Testing
- node --check backend/routes/admin.js
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc12d984c083339fde9f2c084675d8