### PR TITLE
Hide admin journal reminders

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,7 @@
+# 2025-09-27
+- Hid the journal reminder controls on the admin settings page so administrators no longer see the daily reflection or weekly
+  summary toggles.
+
 # 2025-09-26
 - Extended the admin mentorship hub with a new Journaler management panel that lets admins search by name/email, review linked
   mentors, unlink relationships, and delete journaler accounts. Backed the UI with enriched `/admin/journalers` data and a new

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -19,8 +19,8 @@ tays balanced across breakpoints.
   a clear escape hatch.
 - Keep modal headers in a single flex container that houses both the title block and the close button so the markup stays
   balanced and easier to maintain.
-- Admins view a pared-down settings experience: hide mentor notification controls, the weekly summary toggle, profile submit
-  actions, and the data export/deletion tools whenever `user.role === "admin"`.
+- Admins view a pared-down settings experience: hide the email reminder fieldset, mentor notification controls, the weekly
+  summary toggle, profile submit actions, and the data export/deletion tools whenever `user.role === "admin"`.
 - Admin mentor management lives on `/mentorship`: show mentor cards with linked mentees, allow linking by email, and surface a
   `Delete mentor` control using the shared button tokens so admins can curate relationships gracefully.
 - Admin journaler management also lives on `/mentorship`: surface a journaler list with linked mentors, include a search affordance,

--- a/frontend/src/pages/SettingsPage.js
+++ b/frontend/src/pages/SettingsPage.js
@@ -283,19 +283,19 @@ function SettingsPage() {
             />
           </label>
 
-          <fieldset className="space-y-3 rounded-2xl border border-emerald-100 bg-white/60 p-4">
-            <legend className="text-sm font-semibold text-emerald-900">Email reminders</legend>
-            <label className="flex items-center gap-2 text-sm font-medium text-emerald-900/80">
-              <input
-                type="checkbox"
-                name="remindersDaily"
-                className={checkboxClasses}
-                checked={form.remindersDaily}
-                onChange={handleChange}
-              />
-              Daily reflection reminders
-            </label>
-            {!isAdmin && (
+          {!isAdmin && (
+            <fieldset className="space-y-3 rounded-2xl border border-emerald-100 bg-white/60 p-4">
+              <legend className="text-sm font-semibold text-emerald-900">Email reminders</legend>
+              <label className="flex items-center gap-2 text-sm font-medium text-emerald-900/80">
+                <input
+                  type="checkbox"
+                  name="remindersDaily"
+                  className={checkboxClasses}
+                  checked={form.remindersDaily}
+                  onChange={handleChange}
+                />
+                Daily reflection reminders
+              </label>
               <label className="flex items-center gap-2 text-sm font-medium text-emerald-900/80">
                 <input
                   type="checkbox"
@@ -306,8 +306,8 @@ function SettingsPage() {
                 />
                 Weekly summary updates
               </label>
-            )}
-          </fieldset>
+            </fieldset>
+          )}
 
           <fieldset className="space-y-3 rounded-2xl border border-emerald-100 bg-white/60 p-4">
             <legend className="text-sm font-semibold text-emerald-900">


### PR DESCRIPTION
## Summary
- hide the email reminder section for admin users on the settings page
- document the pared-down admin experience in the frontend contributing notes and wiki

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68cc15e072a883339f6a8775ef2a5dca