### PR TITLE
Add live password confirmation validation on registration form

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,9 @@
 
+# 2025-09-28
+- Added a live password confirmation check on `RegisterPage` so the retype field highlights mismatches, shares a gentle reminder,
+  and keeps the submit action disabled until both entries match. Noted the guidance in `frontend/AGENTS.md` for future frontend
+  contributors.
+
 - Added an admin-only Journaler navigation entry that links to the new `/journalers` route where the entire journaler management
   experience now lives. The mentorship view for admins focuses solely on mentor stewardship while the new page handles search,
   unlinking mentors, and deleting journaler accounts with the existing admin endpoints.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -32,4 +32,6 @@ tays balanced across breakpoints.
   accessible labels (use `sr-only` utilities) so screen readers announce each option clearly.
 - Journalers see their assigned forms within `JournalHistoryPage`; keep the poetic CTA that links to `/dashboard?formId=...` using
   the shared `primaryButtonClasses` so each card offers the single-word "Bloom" invitation.
+- The registration form validates password confirmation on the client: highlight the retype input, surface a gentle error message,
+  and prevent submission until both fields match.
 

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -47,10 +47,33 @@ function RegisterPage() {
     },
   });
 
+  const passwordsMismatch =
+    form.confirmPassword && form.password !== form.confirmPassword;
+
+  const syncPasswordMismatchError = (nextForm) => {
+    if (
+      nextForm.confirmPassword &&
+      nextForm.password !== nextForm.confirmPassword
+    ) {
+      setLocalError("Passwords must match");
+    } else {
+      setLocalError(null);
+    }
+  };
+
   const handleChange = (event) => {
     const { name, value } = event.target;
-    setLocalError(null);
-    setForm((prev) => ({ ...prev, [name]: value }));
+    setForm((prev) => {
+      const nextForm = { ...prev, [name]: value };
+
+      if (name === "password" || name === "confirmPassword") {
+        syncPasswordMismatchError(nextForm);
+      } else {
+        setLocalError(null);
+      }
+
+      return nextForm;
+    });
   };
 
   const handleMentorChange = (event) => {
@@ -73,7 +96,7 @@ function RegisterPage() {
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    if (form.password !== form.confirmPassword) {
+    if (passwordsMismatch) {
       setLocalError("Passwords must match");
       return;
     }
@@ -299,9 +322,25 @@ function RegisterPage() {
                 onChange={handleChange}
                 required
                 minLength={8}
-                className={inputClasses}
+                className={`${inputClasses} ${
+                  passwordsMismatch
+                    ? "border-rose-300 focus:border-rose-400 focus:ring-rose-100"
+                    : ""
+                }`}
                 placeholder="Confirm your password"
+                aria-invalid={passwordsMismatch}
+                aria-describedby={
+                  passwordsMismatch ? "confirm-password-error" : undefined
+                }
               />
+              {passwordsMismatch && (
+                <p
+                  id="confirm-password-error"
+                  className={`mt-2 ${bodySmallStrongTextClasses} text-rose-600`}
+                >
+                  Passwords must match before you can continue.
+                </p>
+              )}
             </label>
             <label className={`block ${formLabelClasses}`}>
               Role
@@ -389,7 +428,7 @@ function RegisterPage() {
             <button
               type="submit"
               className={`${primaryButtonClasses} w-full`}
-              disabled={loading}
+              disabled={loading || passwordsMismatch}
             >
               {loading ? "Rooting your account..." : "Create luminous account"}
             </button>


### PR DESCRIPTION
## Summary
- add live password confirmation validation to the register form so the confirm field highlights mismatches, shows an inline prompt, and blocks submission until the entries align
- document the new client-side guidance for password confirmation in `frontend/AGENTS.md` and capture the change in `docs/Wiki.md`

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc2179b06c8333be7753270d2e8d78