### PR TITLE
Open Bloom forms inline from history

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,15 @@
 
+# 2025-09-29
+- Brightened the inline Bloom experience on `JournalHistoryPage` by announcing the active form with a guidance banner, adding a
+  "Jump to form" control that scrolls into view, and softly highlighting the reflection card so journalers instantly notice
+  where to write.
+
+# 2025-09-28
+- Let journalers open assigned forms inline on `JournalHistoryPage` by rendering `JournalEntryForm` when they press the "Bloom"
+  button instead of redirecting through the dashboard. This keeps the CTA styling with `primaryButtonClasses` and allows
+  reflections to begin without leaving the history view.
+- Updated `frontend/AGENTS.md` to capture the inline Bloom guidance so future contributors preserve the on-page experience.
+
 - Added an admin-only Journaler navigation entry that links to the new `/journalers` route where the entire journaler management
   experience now lives. The mentorship view for admins focuses solely on mentor stewardship while the new page handles search,
   unlinking mentors, and deleting journaler accounts with the existing admin endpoints.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -30,6 +30,8 @@ tays balanced across breakpoints.
   the filter controls, and ensure the mentee association list stays actionable with the existing remove affordance.
 - Admins now see the form catalogue under the "Form Management" header; keep the copy aligned and pair the filter controls with
   accessible labels (use `sr-only` utilities) so screen readers announce each option clearly.
-- Journalers see their assigned forms within `JournalHistoryPage`; keep the poetic CTA that links to `/dashboard?formId=...` using
-  the shared `primaryButtonClasses` so each card offers the single-word "Bloom" invitation.
+- Journalers see their assigned forms within `JournalHistoryPage`; the "Bloom" button now opens the form inline on that page.
+  Use the shared `primaryButtonClasses` for the CTA and surface the reflection form with `JournalEntryForm` so journalers never
+  need to detour through the dashboard when starting a new entry. When enhancing this experience, keep the inline guidance card
+  and scroll-to-form affordance so journalers immediately know their chosen prompts have appeared below.
 


### PR DESCRIPTION
## Summary
- show the selected form directly on JournalHistoryPage when a journaler presses Bloom so they can reflect without detouring through the dashboard
- handle inline submission using JournalEntryForm with themed status messaging and reset behavior to keep the experience consistent
- refresh docs and frontend contributing notes to capture the inline Bloom guidance for future changes
- announce the inline form with a guidance banner, jump action, and gentle highlight so journalers immediately see where to write

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc20a89f988333a86dd2304595d691