### PR TITLE
Fix register page password mismatch helper

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -16,6 +16,9 @@
 - Added a live password confirmation check on `RegisterPage` so the retype field highlights mismatches, shares a gentle reminder,
   and keeps the submit action disabled until both entries match. Noted the guidance in `frontend/AGENTS.md` for future frontend
   contributors.
+- Fixed the `RegisterPage` password confirmation helper so `passwordsMismatch` is defined via state and synced on every edit,
+  preventing runtime reference errors while keeping the inline reminder and disabled submit flow intact. Documented the helper in
+  `frontend/AGENTS.md`.
 
 
 - Added an admin-only Journaler navigation entry that links to the new `/journalers` route where the entire journaler management

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -31,6 +31,9 @@ tays balanced across breakpoints.
 - Admins now see the form catalogue under the "Form Management" header; keep the copy aligned and pair the filter controls with
   accessible labels (use `sr-only` utilities) so screen readers announce each option clearly.
 
+- `RegisterPage` keeps the password confirmation helper (`syncPasswordMismatchError`) to disable submission and surface the inline
+  reminder until both entries match—preserve this flow when adjusting the form.
+
 - Journalers see their assigned forms within `JournalHistoryPage`; keep the poetic CTA that links to `/dashboard?formId=...` using
   the shared `primaryButtonClasses` so each card offers the single-word "Bloom" invitation.
 - The shared `TagInput` now highlights matching expertise while listing the top 10 popular tags beneath the field. When supplying

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -34,6 +34,7 @@ function RegisterPage() {
   const [mentorApplicationSubmitted, setMentorApplicationSubmitted] =
     useState(false);
   const [mentorApprovalMessage, setMentorApprovalMessage] = useState("");
+  const [passwordsMismatch, setPasswordsMismatch] = useState(false);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -49,6 +50,22 @@ function RegisterPage() {
   });
 
   const { suggestions: expertiseSuggestions } = useExpertiseSuggestions({ limit: 40 });
+
+  const syncPasswordMismatchError = (nextForm) => {
+    const { password, confirmPassword } = nextForm;
+    const normalizedPassword = (password || "").trim();
+    const normalizedConfirmPassword = (confirmPassword || "").trim();
+    const mismatch =
+      normalizedPassword.length > 0 &&
+      normalizedConfirmPassword.length > 0 &&
+      normalizedPassword !== normalizedConfirmPassword;
+
+    setPasswordsMismatch(mismatch);
+
+    if (!mismatch) {
+      setLocalError(null);
+    }
+  };
 
   const handleChange = (event) => {
     const { name, value } = event.target;


### PR DESCRIPTION
## Summary
- define and sync the register page password mismatch helper state so the confirm field and submit button stay guarded
- document the helper expectation for future frontend contributors and note the fix in the wiki

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc2841e9a483339237df4cfe34844c