### PR TITLE
Guide journalers to inline Bloom form

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -12,6 +12,8 @@
 - Let journalers open assigned forms inline on `JournalHistoryPage` by rendering `JournalEntryForm` when they press the "Bloom"
   button instead of redirecting through the dashboard. This keeps the CTA styling with `primaryButtonClasses` and allows
   reflections to begin without leaving the history view.
+- Guided journalers to the inline Bloom form by auto-scrolling the newly revealed `SectionCard`, focusing its heading, and
+  whispering a status message so the chosen prompts feel nearby. Documented the supporting `SectionCard` refs in `frontend/AGENTS.md`.
 - Updated `frontend/AGENTS.md` to capture the inline Bloom guidance so future contributors preserve the on-page experience.
 - Added a live password confirmation check on `RegisterPage` so the retype field highlights mismatches, shares a gentle reminder,
   and keeps the submit action disabled until both entries match. Noted the guidance in `frontend/AGENTS.md` for future frontend

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -36,6 +36,8 @@ tays balanced across breakpoints.
 
 - Journalers see their assigned forms within `JournalHistoryPage`; keep the poetic CTA that links to `/dashboard?formId=...` using
   the shared `primaryButtonClasses` so each card offers the single-word "Bloom" invitation.
+- `SectionCard` now supports optional `sectionRef`, `titleRef`, and `titleProps` arguments so freshly revealed sections can be
+  scrolled into view or focused for accessibility. Use them when a flow needs to direct attention to inline content.
 - The shared `TagInput` now highlights matching expertise while listing the top 10 popular tags beneath the field. When supplying
   suggestions, pass them in popularity order so mentors always see the gentlest guidance first.
 

--- a/frontend/src/components/SectionCard.js
+++ b/frontend/src/components/SectionCard.js
@@ -4,12 +4,25 @@ import {
   sectionTitleClasses,
 } from "../styles/ui";
 
-function SectionCard({ title, subtitle, action, children, icon }) {
+function SectionCard({
+  title,
+  subtitle,
+  action,
+  children,
+  icon,
+  sectionRef,
+  titleRef,
+  titleProps = {},
+}) {
   const showHeaderText = Boolean(title || subtitle || icon);
   const showHeader = showHeaderText || Boolean(action);
+  const { className: titleClassName = "", ...restTitleProps } = titleProps;
+  const headingClassName = [sectionTitleClasses, titleClassName]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <section className={`${cardContainerClasses} w-full`}>
+    <section ref={sectionRef} className={`${cardContainerClasses} w-full`}>
       {showHeader && (
         <div
           className={`flex flex-wrap items-center gap-4 ${
@@ -18,7 +31,7 @@ function SectionCard({ title, subtitle, action, children, icon }) {
         >
           {showHeaderText && (
             <div className="space-y-1">
-              <h2 className={sectionTitleClasses}>
+              <h2 ref={titleRef} className={headingClassName} {...restTitleProps}>
                 {icon && (
                   <span className="mr-2 inline-flex items-center">{icon}</span>
                 )}

--- a/frontend/src/pages/JournalHistoryPage.js
+++ b/frontend/src/pages/JournalHistoryPage.js
@@ -92,6 +92,8 @@ function JournalHistoryPage() {
   const [activeFormStatusMessage, setActiveFormStatusMessage] = useState(null);
   const [activeFormStatusVariant, setActiveFormStatusVariant] = useState("info");
   const [activeFormResetKey, setActiveFormResetKey] = useState(0);
+  const activeFormSectionRef = useRef(null);
+  const activeFormHeadingRef = useRef(null);
 
   const loadEntries = useCallback(async () => {
     if (!token) return;
@@ -235,7 +237,9 @@ function JournalHistoryPage() {
   const handleOpenForm = useCallback((formId) => {
     setActiveFormId(formId);
     setActiveFormStatusVariant("info");
-    setActiveFormStatusMessage(null);
+    setActiveFormStatusMessage(
+      "Your chosen form now blossoms just below this list."
+    );
     setActiveFormResetKey((prev) => prev + 1);
   }, []);
 
@@ -280,13 +284,35 @@ function JournalHistoryPage() {
   );
 
   useEffect(() => {
-    if (activeFormStatusVariant !== "success" || !activeFormStatusMessage) {
+    if (!activeFormStatusMessage) {
       return undefined;
     }
 
-    const timeout = setTimeout(() => setActiveFormStatusMessage(null), 4000);
+    const timeout = setTimeout(
+      () => setActiveFormStatusMessage(null),
+      activeFormStatusVariant === "success" ? 4000 : 6000
+    );
     return () => clearTimeout(timeout);
   }, [activeFormStatusMessage, activeFormStatusVariant]);
+
+  useEffect(() => {
+    if (!activeForm || !activeFormSectionRef.current) {
+      return;
+    }
+
+    activeFormSectionRef.current.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+
+    if (activeFormHeadingRef.current) {
+      try {
+        activeFormHeadingRef.current.focus({ preventScroll: true });
+      } catch (err) {
+        activeFormHeadingRef.current.focus();
+      }
+    }
+  }, [activeForm]);
 
   const sortedForms = useMemo(() => {
     if (!Array.isArray(forms)) {
@@ -643,6 +669,9 @@ function JournalHistoryPage() {
       )}
       {user.role === "journaler" && activeForm && (
         <SectionCard
+          sectionRef={activeFormSectionRef}
+          titleRef={activeFormHeadingRef}
+          titleProps={{ tabIndex: -1 }}
           title="Today’s reflection"
           subtitle="Offer your thoughts to the chosen canopy without leaving your history"
         >


### PR DESCRIPTION
## Summary
- enhance SectionCard with optional refs so inline sections can be scrolled into view or focused when revealed
- reassure journalers when they open a Bloom form by auto-scrolling to the inline form, focusing its heading, and showing a gentle status message
- document the new guidance in frontend/AGENTS.md and docs/Wiki.md

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc299d553c83338fe9d106a21f7c97