### PR TITLE
Add global error boundary for Aleya frontend

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,9 @@
 
+# 2025-09-29
+
+- Wrapped the authenticated shell with a new `GlobalErrorBoundary` component that renders a gentle fallback, offers retry and reload affordances, and records window errors plus unhandled promise rejections so runtime exceptions no longer splash raw traces across the UI.
+- Added `frontend/AGENTS.md` guidance describing how to extend the boundary while keeping technical diagnostics tucked behind the existing disclosure toggle.
+
 # 2025-09-28
 
 - Introduced a public `/api/auth/expertise` endpoint that aggregates mentor profile keywords, returning the most common tags in

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -42,3 +42,5 @@ tays balanced across breakpoints.
   suggestions, pass them in popularity order so mentors always see the gentlest guidance first.
 
 
+- `GlobalErrorBoundary` wraps the authenticated shell and listens for unhandled promise rejections and window errors. When adjusting global error flows, reuse the boundary’s reset and reload affordances, keep the fallback copy within Aleya’s luminous tone, and prefer surfacing technical details behind the existing "technical whispers" toggle instead of introducing new disclosure patterns.
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Navigate, Route, Routes } from "react-router-d
 import Layout from "./components/Layout";
 import { AuthProvider, useAuth } from "./context/AuthContext";
 import { NotificationProvider } from "./context/NotificationContext";
+import GlobalErrorBoundary from "./components/GlobalErrorBoundary";
 import LandingPage from "./pages/LandingPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
@@ -52,74 +53,76 @@ function AppRoutes() {
   const { user } = useAuth();
 
   return (
-    <NotificationProvider>
-      <Layout>
-        <Routes>
-        <Route
-          path="/"
-          element={user ? <Navigate to="/dashboard" replace /> : <LandingPage />}
-        />
-        <Route
-          path="/login"
-          element={user ? <Navigate to="/dashboard" replace /> : <LoginPage />}
-        />
-        <Route
-          path="/register"
-          element={user ? <Navigate to="/dashboard" replace /> : <RegisterPage />}
-        />
-        <Route path="/verify-email" element={<VerifyEmailPage />} />
-        <Route
-          path="/dashboard"
-          element={
-            <ProtectedRoute>
-              <DashboardRouter />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/journal/history"
-          element={
-            <ProtectedRoute roles={["journaler", "mentor"]}>
-              <JournalHistoryPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/mentorship"
-          element={
-            <ProtectedRoute roles={["journaler", "mentor", "admin"]}>
-              <MentorConnectionsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/journalers"
-          element={
-            <ProtectedRoute roles={["admin"]}>
-              <JournalerManagementPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/forms"
-          element={
-            <ProtectedRoute roles={["mentor", "admin"]}>
-              <FormBuilderPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/settings"
-          element={
-            <ProtectedRoute roles={["journaler", "mentor", "admin"]}>
-              <SettingsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Layout>
-    </NotificationProvider>
+    <GlobalErrorBoundary>
+      <NotificationProvider>
+        <Layout>
+          <Routes>
+            <Route
+              path="/"
+              element={user ? <Navigate to="/dashboard" replace /> : <LandingPage />}
+            />
+            <Route
+              path="/login"
+              element={user ? <Navigate to="/dashboard" replace /> : <LoginPage />}
+            />
+            <Route
+              path="/register"
+              element={user ? <Navigate to="/dashboard" replace /> : <RegisterPage />}
+            />
+            <Route path="/verify-email" element={<VerifyEmailPage />} />
+            <Route
+              path="/dashboard"
+              element={
+                <ProtectedRoute>
+                  <DashboardRouter />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/journal/history"
+              element={
+                <ProtectedRoute roles={["journaler", "mentor"]}>
+                  <JournalHistoryPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/mentorship"
+              element={
+                <ProtectedRoute roles={["journaler", "mentor", "admin"]}>
+                  <MentorConnectionsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/journalers"
+              element={
+                <ProtectedRoute roles={["admin"]}>
+                  <JournalerManagementPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/forms"
+              element={
+                <ProtectedRoute roles={["mentor", "admin"]}>
+                  <FormBuilderPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/settings"
+              element={
+                <ProtectedRoute roles={["journaler", "mentor", "admin"]}>
+                  <SettingsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Layout>
+      </NotificationProvider>
+    </GlobalErrorBoundary>
   );
 }
 

--- a/frontend/src/components/GlobalErrorBoundary.js
+++ b/frontend/src/components/GlobalErrorBoundary.js
@@ -1,0 +1,215 @@
+import { Component } from "react";
+import {
+  bodySmallMutedTextClasses,
+  bodyTextClasses,
+  largeHeadingClasses,
+  primaryButtonClasses,
+  secondaryButtonClasses,
+} from "../styles/ui";
+
+function buildWindowContext(event) {
+  if (!event) {
+    return null;
+  }
+
+  const details = [];
+  if (event.filename) {
+    const position = [event.lineno, event.colno]
+      .filter((value) => Number.isFinite(value))
+      .join(":");
+    details.push(`Source: ${event.filename}${position ? `:${position}` : ""}`);
+  }
+
+  if (event.reason && typeof event.reason === "string") {
+    details.push(`Reason: ${event.reason}`);
+  }
+
+  if (event.message) {
+    details.push(`Message: ${event.message}`);
+  }
+
+  return details.length ? details.join("\n") : null;
+}
+
+class GlobalErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    };
+  }
+
+  static getDerivedStateFromError(error) {
+    return {
+      hasError: true,
+      error,
+      errorInfo: null,
+      showDetails: false,
+    };
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({
+      errorInfo: info?.componentStack || null,
+    });
+    this.reportError(error, {
+      source: "react",
+      componentStack: info?.componentStack,
+    });
+  }
+
+  componentDidMount() {
+    window.addEventListener("error", this.handleWindowError);
+    window.addEventListener("unhandledrejection", this.handleUnhandledRejection);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("error", this.handleWindowError);
+    window.removeEventListener(
+      "unhandledrejection",
+      this.handleUnhandledRejection
+    );
+  }
+
+  handleWindowError = (event) => {
+    const error = event?.error || new Error(event?.message || "Unexpected error");
+    const errorInfo = buildWindowContext(event);
+
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo,
+      showDetails: false,
+    });
+
+    this.reportError(error, {
+      source: "window.error",
+      context: errorInfo,
+    });
+  };
+
+  handleUnhandledRejection = (event) => {
+    const reason = event?.reason;
+    const error =
+      reason instanceof Error
+        ? reason
+        : new Error(
+            typeof reason === "string"
+              ? reason
+              : "Unhandled promise rejection"
+          );
+
+    const errorInfo = buildWindowContext(event);
+
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo,
+      showDetails: false,
+    });
+
+    this.reportError(error, {
+      source: "window.unhandledrejection",
+      context: errorInfo,
+    });
+  };
+
+  reportError(error, metadata) {
+    if (process.env.NODE_ENV !== "test") {
+      // eslint-disable-next-line no-console
+      console.error("Global error captured", error, metadata);
+    }
+
+    if (typeof this.props.onError === "function") {
+      this.props.onError(error, metadata);
+    }
+  }
+
+  handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      showDetails: false,
+    });
+
+    if (typeof this.props.onReset === "function") {
+      this.props.onReset();
+    }
+  };
+
+  handleReload = () => {
+    if (typeof window !== "undefined") {
+      window.location.assign(window.location.origin);
+    }
+  };
+
+  toggleDetails = () => {
+    this.setState((previous) => ({
+      showDetails: !previous.showDetails,
+    }));
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    const { error, errorInfo, showDetails } = this.state;
+    const detailContent = error?.stack || errorInfo || "";
+
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-emerald-100 px-6 py-16">
+        <div className="w-full max-w-xl rounded-3xl border border-emerald-200/70 bg-white/80 p-10 text-center shadow-lg shadow-emerald-200/50 backdrop-blur">
+          <h1 className={`${largeHeadingClasses} text-emerald-900`}>We wandered into a thicket.</h1>
+          <p className={`${bodyTextClasses} mt-4 text-emerald-900/80`}>
+            Something unexpected rustled the canopy. We have safely paused the experience
+            so you can choose how to continue.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-3">
+            <button
+              type="button"
+              className={`${primaryButtonClasses} px-6 py-2.5`}
+              onClick={this.handleReset}
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              className={`${secondaryButtonClasses} px-6 py-2.5`}
+              onClick={this.handleReload}
+            >
+              Return to the clearing
+            </button>
+          </div>
+          {detailContent ? (
+            <div className="mt-8 text-left">
+              <button
+                type="button"
+                className={`${bodyTextClasses} underline-offset-4 transition hover:underline`}
+                onClick={this.toggleDetails}
+              >
+                {showDetails ? "Hide technical whispers" : "Show technical whispers"}
+              </button>
+              {showDetails ? (
+                <pre
+                  className={`${bodySmallMutedTextClasses} mt-4 max-h-48 overflow-auto rounded-2xl bg-emerald-50/80 p-4 text-sm leading-relaxed`}
+                >
+                  {detailContent}
+                </pre>
+              ) : null}
+            </div>
+          ) : null}
+          <p className={`${bodySmallMutedTextClasses} mt-8`}>
+            If the path keeps closing, please share these details with the Aleya team so we can guide the light back home.
+          </p>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default GlobalErrorBoundary;


### PR DESCRIPTION
## Summary
- add a reusable `GlobalErrorBoundary` that captures render failures, window errors, and unhandled rejections before presenting a luminous fallback with reset and reload affordances
- wrap the authenticated app shell with the new boundary so unexpected exceptions surface the friendly experience instead of raw stack traces
- document the boundary expectations in `frontend/AGENTS.md` and record the global error handling standard in `docs/Wiki.md`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68cc2bb6c2508333903fdddde7455fd6