### PR TITLE
Send mentor application emails

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -16,3 +16,6 @@
   endpoint.
 - The public `/api/auth/expertise` route aggregates mentor profile keywords for registration suggestions—keep its splitting logic
   aligned with the frontend `parseExpertise` helper whenever you adjust how expertise data is stored.
+- Mentor registration now dispatches the `mentor_application_submitted_mentor` notification so mentors receive an acknowledgement
+  email while their application awaits admin review. Preserve this flow when changing the register route or notification
+  templates so both mentors and admins stay informed.

--- a/backend/utils/notifications.js
+++ b/backend/utils/notifications.js
@@ -191,6 +191,30 @@ const NOTIFICATION_TEMPLATES = {
         `<p>Rooted in care,<br/>The Aleya team</p>`,
     }),
   },
+  mentor_application_submitted_mentor: {
+    category: "account",
+    emailTemplate: "mentor_application_submitted",
+    buildInApp: ({ mentor }) => ({
+      title: "We received your mentor application",
+      body:
+        "Thank you for offering your guidance. Our admin team will review your details and email you once a decision is made.",
+      actionLabel: "Visit Aleya",
+      actionUrl: buildFrontendLink("/dashboard"),
+      metadata: {
+        mentorId: mentor.id,
+        status: "pending",
+      },
+    }),
+    buildEmail: ({ mentor }) => ({
+      to: mentor.email,
+      subject: "We received your mentor application",
+      text: `Hi ${mentor.name || "there"},\n\nThank you for offering to mentor on Aleya. An administrator will review your application shortly. We'll send another note as soon as a decision is ready.\n\nRooted in care,\nThe Aleya team`,
+      html: `<p>Hi ${mentor.name || "there"},</p>` +
+        `<p>Thank you for offering to mentor on Aleya. An administrator will review your application shortly.</p>` +
+        `<p>We'll send another note as soon as a decision is ready.</p>` +
+        `<p>Rooted in care,<br/>The Aleya team</p>`,
+    }),
+  },
   mentor_application_decision: {
     category: "account",
     emailTemplate: "mentor_application_decision",

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,6 +1,14 @@
 
 # 2025-09-28
 
+- Ensured mentor registrations send acknowledgement emails by introducing the
+  `mentor_application_submitted_mentor` notification so new mentors know their
+  application is awaiting admin review while admins still receive their bell
+  alert and email summary.
+- Updated the registration flow to capture the inserted user's notification
+  preferences and dispatch the mentor acknowledgement alongside the existing
+  admin email so both sides stay informed during approval.
+
 - Introduced a public `/api/auth/expertise` endpoint that aggregates mentor profile keywords, returning the most common tags in
   popularity order so registration flows can suggest existing expertise. The splitter mirrors `parseExpertise` to keep frontend
   and backend normalization aligned.


### PR DESCRIPTION
## Summary
- add a dedicated `mentor_application_submitted_mentor` notification template so new mentors receive an acknowledgement email
- capture the inserted user's notification preferences when registering and dispatch the mentor acknowledgement alongside the admin alert
- document the updated mentor registration email flow in backend contributing notes and the repository wiki

## Testing
- node --check backend/routes/auth.js
- node --check backend/utils/notifications.js

------
https://chatgpt.com/codex/tasks/task_e_68cc2cb5510483338f57aec39dc019f8