### PR TITLE
Allow mentors to register without admin approval

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -16,6 +16,6 @@
   endpoint.
 - The public `/api/auth/expertise` route aggregates mentor profile keywords for registration suggestions—keep its splitting logic
   aligned with the frontend `parseExpertise` helper whenever you adjust how expertise data is stored.
-- Mentor registration now dispatches the `mentor_application_submitted_mentor` notification so mentors receive an acknowledgement
-  email while their application awaits admin review. Preserve this flow when changing the register route or notification
-  templates so both mentors and admins stay informed.
+- Mentor registration now mirrors the mentee flow: accounts are created immediately, mentors receive the usual verification
+  email, and the follow-up acknowledgement comes from the `mentor_registered_mentor` notification while admins get
+  `mentor_registered_admin`. Keep these notices aligned with the registration experience.

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -276,64 +276,6 @@ router.post(
     try {
       await client.query("BEGIN");
 
-      let mentorApproval;
-      if (role === "mentor") {
-        const applicationDetails = {
-          name: trimmedName || name || "",
-          timezone: resolvedTimezone,
-          mentorProfile: mentorProfile || {},
-        };
-
-        const { rows: approvals } = await client.query(
-          `SELECT * FROM mentor_approvals WHERE email = $1 FOR UPDATE`,
-          [normalizedEmail]
-        );
-
-        if (!approvals.length) {
-          const { rows: insertedApproval } = await client.query(
-            `INSERT INTO mentor_approvals (email, name, application)
-             VALUES ($1, $2, $3)
-             RETURNING *`,
-            [normalizedEmail, trimmedName || name || null, JSON.stringify(applicationDetails)]
-          );
-          mentorApproval = insertedApproval[0];
-        } else {
-          mentorApproval = approvals[0];
-
-          if (mentorApproval.status !== "approved") {
-            const { rows: updatedApproval } = await client.query(
-              `UPDATE mentor_approvals
-               SET name = $2,
-                   application = $3,
-                   status = 'pending',
-                   requested_at = NOW(),
-                   decided_at = NULL,
-                   decided_by = NULL
-               WHERE id = $1 AND status <> 'approved'
-               RETURNING *`,
-              [
-                mentorApproval.id,
-                trimmedName || name || null,
-                JSON.stringify(applicationDetails),
-              ]
-            );
-
-            if (updatedApproval.length) {
-              mentorApproval = updatedApproval[0];
-            }
-          }
-        }
-
-        if (!mentorApproval || mentorApproval.status !== "approved") {
-          await client.query("ROLLBACK");
-          return res.status(403).json({
-            error:
-              "Thanks for your interest in mentoring. An administrator must approve your application before you can register.",
-            code: "mentor_approval_required",
-          });
-        }
-      }
-
       const existing = await client.query(
         "SELECT id FROM users WHERE email = $1",
         [normalizedEmail]
@@ -432,12 +374,12 @@ router.post(
       } else if (role === "mentor") {
         await notifyAdmins(
           req.app,
-          "mentor_application_submitted_admin",
+          "mentor_registered_admin",
           () => ({ mentor: newUser })
         );
         await dispatchNotification(
           req.app,
-          "mentor_application_submitted_mentor",
+          "mentor_registered_mentor",
           {
             recipient: mentorRecipient,
             mentor: newUser,

--- a/backend/utils/notifications.js
+++ b/backend/utils/notifications.js
@@ -163,13 +163,13 @@ const NOTIFICATION_TEMPLATES = {
         `<p>Rooted in care,<br/>The Aleya team</p>`,
     }),
   },
-  mentor_application_submitted_admin: {
+  mentor_registered_admin: {
     category: "account",
     emailTemplate: "mentor_application_submitted",
     buildInApp: ({ mentor }) => ({
-      title: `${mentor.name || mentor.email} applied to be a mentor`,
-      body: `${mentor.name || mentor.email} requested mentor access. Review their application to keep the directory current.`,
-      actionLabel: "Review mentor applications",
+      title: `${mentor.name || mentor.email} joined as a mentor`,
+      body: `${mentor.name || mentor.email} just registered as a mentor on Aleya. Welcome them aboard whenever you have a moment.`,
+      actionLabel: "Open dashboard",
       actionUrl: buildFrontendLink("/dashboard"),
       metadata: {
         email: mentor.email,
@@ -177,41 +177,40 @@ const NOTIFICATION_TEMPLATES = {
     }),
     buildEmail: ({ recipient, mentor }) => ({
       to: recipient.email,
-      subject: `Mentor application received: ${mentor.name || mentor.email}`,
+      subject: `New mentor registration: ${mentor.name || mentor.email}`,
       text: `Hi ${recipient.name || "there"},\n\n${
         mentor.name || mentor.email
-      } submitted a mentor application on Aleya.\n\nVisit ${buildFrontendLink(
+      } just registered as a mentor on Aleya.\n\nVisit ${buildFrontendLink(
         "/dashboard"
-      )} to review and respond.\n\nRooted in care,\nThe Aleya team`,
+      )} to share a welcome or ensure they have the resources they need.\n\nRooted in care,\nThe Aleya team`,
       html: `<p>Hi ${recipient.name || "there"},</p>` +
-        `<p><strong>${mentor.name || mentor.email}</strong> submitted a mentor application on Aleya.</p>` +
+        `<p><strong>${mentor.name || mentor.email}</strong> just registered as a mentor on Aleya.</p>` +
         `<p><a href="${buildFrontendLink(
           "/dashboard"
-        )}" style="display:inline-block;padding:12px 20px;background:#2f855a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Review mentor approvals</a></p>` +
+        )}" style="display:inline-block;padding:12px 20px;background:#2f855a;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Open dashboard</a></p>` +
         `<p>Rooted in care,<br/>The Aleya team</p>`,
     }),
   },
-  mentor_application_submitted_mentor: {
+  mentor_registered_mentor: {
     category: "account",
     emailTemplate: "mentor_application_submitted",
     buildInApp: ({ mentor }) => ({
-      title: "We received your mentor application",
+      title: "Welcome to Aleya's mentor grove",
       body:
-        "Thank you for offering your guidance. Our admin team will review your details and email you once a decision is made.",
-      actionLabel: "Visit Aleya",
-      actionUrl: buildFrontendLink("/dashboard"),
+        "Thank you for sharing your wisdom. Verify your email to finish setting up your account, then sign in to start supporting journalers.",
+      actionLabel: "Verify your email",
+      actionUrl: buildFrontendLink("/login"),
       metadata: {
         mentorId: mentor.id,
-        status: "pending",
       },
     }),
     buildEmail: ({ mentor }) => ({
       to: mentor.email,
-      subject: "We received your mentor application",
-      text: `Hi ${mentor.name || "there"},\n\nThank you for offering to mentor on Aleya. An administrator will review your application shortly. We'll send another note as soon as a decision is ready.\n\nRooted in care,\nThe Aleya team`,
+      subject: "Welcome to Aleya as a mentor",
+      text: `Hi ${mentor.name || "there"},\n\nThank you for offering to mentor on Aleya. Please verify your email address so you can sign in and begin supporting journalers.\n\nRooted in care,\nThe Aleya team`,
       html: `<p>Hi ${mentor.name || "there"},</p>` +
-        `<p>Thank you for offering to mentor on Aleya. An administrator will review your application shortly.</p>` +
-        `<p>We'll send another note as soon as a decision is ready.</p>` +
+        `<p>Thank you for offering to mentor on Aleya.</p>` +
+        `<p>Please verify your email address so you can sign in and begin supporting journalers.</p>` +
         `<p>Rooted in care,<br/>The Aleya team</p>`,
     }),
   },

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,14 @@
 
+# 2025-09-30
+
+- Let mentor registrations follow the mentee workflow by removing the `mentor_approvals`
+  gate in `backend/routes/auth.js`, allowing accounts to be created immediately and email
+  verification links to be dispatched without waiting for admin review.
+- Replaced the mentor application notifications with the new
+  `mentor_registered_admin` and `mentor_registered_mentor` messages so admins still receive
+  a heads-up while mentors get a welcome focused on verifying their email rather than
+  awaiting approval.
+
 # 2025-09-29
 
 - Wrapped the authenticated shell with a new `GlobalErrorBoundary` component that renders a gentle fallback, offers retry and reload affordances, and records window errors plus unhandled promise rejections so runtime exceptions no longer splash raw traces across the UI.


### PR DESCRIPTION
## Summary
- allow mentor sign ups to bypass the mentor_approvals gate so verification emails go out immediately
- refresh mentor registration notifications for mentors and admins to match the new flow
- document the streamlined mentor registration workflow in backend guidance and the wiki

## Testing
- node --check backend/routes/auth.js
- node --check backend/utils/notifications.js

------
https://chatgpt.com/codex/tasks/task_e_68cc2ff1e8e48333907eff65a5a21ac5