### PR TITLE
Improve admin form library layout

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,8 @@
 
+# 2025-10-04
+
+- Refined the admin dashboard form library into responsive cards that surface friendly visibility and assignment labels, and documented the `table-header`/`table-row` token pattern in `frontend/AGENTS.md` so future tables keep the stacked mobile layout.
+
 # 2025-10-03
 
 - Introduced `backend/utils/emailTemplates.js` as the shared theme wrapper for transactional emails, ensuring subjects include the

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -30,6 +30,8 @@ tays balanced across breakpoints.
   the filter controls, and ensure the mentee association list stays actionable with the existing remove affordance.
 - Admins now see the form catalogue under the "Form Management" header; keep the copy aligned and pair the filter controls with
   accessible labels (use `sr-only` utilities) so screen readers announce each option clearly.
+- The shared `table-header` and `table-row` tokens power the responsive admin tables. They collapse into stacked cards on small
+  screens and expand to the three-column grid on medium breakpoints—preserve that pattern when listing forms or similar resources.
 
 - `RegisterPage` keeps the password confirmation helper (`syncPasswordMismatchError`) to disable submission and surface the inline
   reminder until both entries match—preserve this flow when adjusting the form.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -88,11 +88,11 @@
   }
 
   .table-header {
-    @apply grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 text-sm font-semibold text-emerald-900/70;
+    @apply hidden grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 text-sm font-semibold text-emerald-900/70 md:grid;
   }
 
   .table-row {
-    @apply grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 rounded-2xl border border-emerald-100 bg-white/70 px-4 py-3 text-sm text-emerald-900;
+    @apply flex flex-col gap-3 rounded-2xl border border-emerald-100 bg-white/70 px-4 py-4 text-sm text-emerald-900 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center md:gap-4 md:py-3;
   }
 
   .card-container {

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -59,6 +59,41 @@ function AdminDashboard() {
     return <LoadingState label="Loading admin overview" />;
   }
 
+  const getVisibilityLabel = (form) => {
+    if (form.is_default) {
+      return "Default template";
+    }
+
+    switch (form.visibility) {
+      case "mentor":
+        return "Mentor library";
+      case "admin":
+        return "Admin only";
+      case "journaler":
+        return "Journaler library";
+      default:
+        return "Shared";
+    }
+  };
+
+  const getAssignmentLabel = (form) => {
+    if (form.is_default) {
+      return "Available to every journaler";
+    }
+
+    const total = Number(form.assignments) || 0;
+
+    if (total === 0) {
+      return "Not assigned yet";
+    }
+
+    if (total === 1) {
+      return "Assigned to 1 journaler";
+    }
+
+    return `Assigned to ${total} journalers`;
+  };
+
   return (
     <div className="flex w-full flex-1 flex-col gap-8">
       <SectionCard
@@ -104,18 +139,33 @@ function AdminDashboard() {
       >
         {forms.length ? (
           <div className="space-y-3">
-            <div className={tableHeaderClasses}>
+            <div className={`${tableHeaderClasses} md:px-4`}>
               <span>Title</span>
               <span>Visibility</span>
-              <span>Assignments</span>
+              <span className="md:text-right">Assignments</span>
             </div>
-            {forms.map((form) => (
-              <div className={tableRowClasses} key={form.id}>
-                <span className="font-semibold text-emerald-900">{form.title}</span>
-                <span className={`${chipBaseClasses} capitalize`}>{form.visibility}</span>
-                <span className="text-sm text-emerald-900/70">{form.assignments}</span>
-              </div>
-            ))}
+            {forms.map((form) => {
+              const visibilityLabel = getVisibilityLabel(form);
+              const assignmentLabel = getAssignmentLabel(form);
+
+              return (
+                <div className={tableRowClasses} key={form.id}>
+                  <div>
+                    <p className="font-semibold text-emerald-900">{form.title}</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-emerald-900/70 md:hidden">
+                      <span className={chipBaseClasses}>{visibilityLabel}</span>
+                      <span>{assignmentLabel}</span>
+                    </div>
+                  </div>
+                  <div className="hidden md:block">
+                    <span className={chipBaseClasses}>{visibilityLabel}</span>
+                  </div>
+                  <div className="hidden text-sm text-emerald-900/80 md:block md:text-right">
+                    {assignmentLabel}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         ) : (
           <p className={emptyStateClasses}>


### PR DESCRIPTION
## Summary
- restyle the admin dashboard form library into responsive cards with contextual visibility and assignment labels
- update the shared table tokens and contributor guidance to reflect the new stacked-to-grid behavior
- log the dashboard refresh in the docs wiki for future reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc48588e3c8333b5cd96438dc05d79