### PR TITLE
Align admin form library with table layout

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,10 @@
 
+# 2025-10-05
+
+- Shifted the admin form catalogue on `FormBuilderPage` into the shared table layout so titles, visibilities, mentee chips, and
+  delete controls align with the Mentor Directory styling across breakpoints.
+- Captured the four-column table guidance in `frontend/AGENTS.md` to keep future tweaks anchored to the dashboard table pattern.
+
 # 2025-10-04
 
 - Refined the admin dashboard form library into responsive cards that surface friendly visibility and assignment labels, and documented the `table-header`/`table-row` token pattern in `frontend/AGENTS.md` so future tables keep the stacked mobile layout.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -32,6 +32,7 @@ tays balanced across breakpoints.
   accessible labels (use `sr-only` utilities) so screen readers announce each option clearly.
 - The shared `table-header` and `table-row` tokens power the responsive admin tables. They collapse into stacked cards on small
   screens and expand to the three-column grid on medium breakpoints—preserve that pattern when listing forms or similar resources.
+- `FormBuilderPage` now leans on the table tokens for admin form stewardship. Keep the four-column medium grid (`title`, `visibility`, `assignments`, `actions`) so delete controls and mentee chips stay aligned with the dashboard's other tables.
 
 - `RegisterPage` keeps the password confirmation helper (`syncPasswordMismatchError`) to disable submission and surface the inline
   reminder until both entries match—preserve this flow when adjusting the form.

--- a/frontend/src/pages/FormBuilderPage.js
+++ b/frontend/src/pages/FormBuilderPage.js
@@ -5,7 +5,6 @@ import SectionCard from "../components/SectionCard";
 import { useAuth } from "../context/AuthContext";
 import {
   checkboxClasses,
-  chipBaseClasses,
   dangerButtonClasses,
   emptyStateClasses,
   infoTextClasses,
@@ -17,6 +16,9 @@ import {
   selectCompactClasses,
   subtleButtonClasses,
   textareaClasses,
+  chipBaseClasses,
+  tableHeaderClasses,
+  tableRowClasses,
 } from "../styles/ui";
 
 const FIELD_TYPES = [
@@ -460,83 +462,89 @@ function FormBuilderPage() {
         )}
 
         {filteredForms.length ? (
-          <ul className="grid gap-4">
+          <div className="space-y-3">
+            <div
+              className={`${tableHeaderClasses} md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] md:px-4`}
+            >
+              <span>Title</span>
+              <span>Visibility</span>
+              <span>Assignments</span>
+              <span className="md:text-right">Actions</span>
+            </div>
             {filteredForms.map((form) => {
               const mentees = Array.isArray(form.mentees)
                 ? form.mentees.filter((mentee) => mentee && mentee.id)
                 : [];
 
               return (
-                <li
+                <div
                   key={form.id}
-                  className="space-y-4 rounded-2xl border border-emerald-100 bg-white/70 p-5"
+                  className={`${tableRowClasses} md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto]`}
                 >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-2">
-                      <p className="text-base font-semibold text-emerald-900">
-                        {form.title}
+                  <div className="space-y-2">
+                    <p className="text-base font-semibold text-emerald-900">
+                      {form.title}
+                    </p>
+                    {form.description && (
+                      <p className="text-sm text-emerald-900/70">{form.description}</p>
+                    )}
+                    {isAdmin && (
+                      <p className={`${mutedTextClasses} text-sm`}>
+                        Created by {form.creatorName || "Unknown creator"}
                       </p>
-                      {form.description && (
-                        <p className="text-sm text-emerald-900/70">{form.description}</p>
-                      )}
-                      {isAdmin && (
-                        <p className={`${mutedTextClasses} text-sm`}>
-                          Created by {form.creatorName || "Unknown creator"}
-                        </p>
-                      )}
-                    </div>
-                    <div className="flex flex-col items-end gap-2">
-                      <span className={chipBaseClasses}>{form.visibility}</span>
-                      {isAdmin && (
-                        <>
-                          <button
-                            type="button"
-                            className={`${dangerButtonClasses} px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60`}
-                            disabled={form.is_default}
-                            onClick={() => handleDeleteForm(form.id)}
-                          >
-                            Delete form
-                          </button>
-                          {form.is_default && (
-                            <p className={`${mutedTextClasses} text-xs text-right`}>
-                              Default forms cannot be removed.
-                            </p>
-                          )}
-                        </>
-                      )}
-                    </div>
+                    )}
                   </div>
-                  {isAdmin && (
-                    <div className="space-y-2 border-t border-emerald-100 pt-4">
-                      <p className="text-sm font-semibold text-emerald-900">
-                        Assigned mentees
+                  <div className="flex flex-wrap items-center gap-2 md:block">
+                    <span className={chipBaseClasses}>{form.visibility}</span>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-sm font-semibold text-emerald-900 md:hidden">
+                      Assigned mentees
+                    </p>
+                    {mentees.length ? (
+                      <ul className="flex flex-wrap gap-2">
+                        {mentees.map((mentee) => (
+                          <li key={mentee.id} className="flex items-center gap-2">
+                            <span className={chipBaseClasses}>{mentee.name}</span>
+                            <button
+                              type="button"
+                              className={`${subtleButtonClasses} px-3 py-1 text-xs`}
+                              onClick={() => handleRemoveAssignment(form.id, mentee.id)}
+                            >
+                              Remove
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className={`${mutedTextClasses} text-sm`}>
+                        No mentees linked yet.
                       </p>
-                      {mentees.length ? (
-                        <ul className="flex flex-wrap gap-2">
-                          {mentees.map((mentee) => (
-                            <li key={mentee.id} className="flex items-center gap-2">
-                              <span className={chipBaseClasses}>{mentee.name}</span>
-                              <button
-                                type="button"
-                                className={`${subtleButtonClasses} px-3 py-1 text-xs`}
-                                onClick={() => handleRemoveAssignment(form.id, mentee.id)}
-                              >
-                                Remove
-                              </button>
-                            </li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <p className={`${mutedTextClasses} text-sm`}>
-                          No mentees linked yet.
-                        </p>
-                      )}
-                    </div>
-                  )}
-                </li>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-2 md:items-end">
+                    {isAdmin && (
+                      <>
+                        <button
+                          type="button"
+                          className={`${dangerButtonClasses} w-full px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60 md:w-auto`}
+                          disabled={form.is_default}
+                          onClick={() => handleDeleteForm(form.id)}
+                        >
+                          Delete form
+                        </button>
+                        {form.is_default && (
+                          <p className={`${mutedTextClasses} text-xs md:text-right`}>
+                            Default forms cannot be removed.
+                          </p>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
               );
             })}
-          </ul>
+          </div>
         ) : (
           <p className={emptyStateClasses}>No forms available yet.</p>
         )}


### PR DESCRIPTION
## Summary
- restyle the admin form catalogue on FormBuilderPage to use the shared table header/row tokens and align the visibility, assignments, and actions columns
- keep mentee chips and delete controls responsive inside the new table layout
- document the refreshed grid guidance in frontend/AGENTS.md and log the change in docs/Wiki.md

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc4b1e2d8883338eb49d13a4c159d5