### PR TITLE
Align admin form library table layout

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,11 @@
 
+# 2025-10-06
+
+- Reworked the admin form library table to drive its column layout through a shared `--table-grid` CSS variable so headers and
+  rows stay aligned with the mentor directory pattern.
+- Updated `frontend/src/index.css` to read the column template from the custom property and documented the override flow in
+  `frontend/AGENTS.md` for future dashboard table tweaks.
+
 # 2025-10-05
 
 - Shifted the admin form catalogue on `FormBuilderPage` into the shared table layout so titles, visibilities, mentee chips, and

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -32,7 +32,8 @@ tays balanced across breakpoints.
   accessible labels (use `sr-only` utilities) so screen readers announce each option clearly.
 - The shared `table-header` and `table-row` tokens power the responsive admin tables. They collapse into stacked cards on small
   screens and expand to the three-column grid on medium breakpoints—preserve that pattern when listing forms or similar resources.
-- `FormBuilderPage` now leans on the table tokens for admin form stewardship. Keep the four-column medium grid (`title`, `visibility`, `assignments`, `actions`) so delete controls and mentee chips stay aligned with the dashboard's other tables.
+  Override the column template with the `--table-grid` CSS variable when a layout needs more (or fewer) columns so headers and rows stay aligned.
+- `FormBuilderPage` now leans on the table tokens for admin form stewardship. Keep the four-column medium grid (`title`, `visibility`, `assignments`, `actions`) so delete controls and mentee chips stay aligned with the dashboard's other tables by setting `style={{ "--table-grid": "minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1.5fr) auto" }}` on both the header and each row.
 
 - `RegisterPage` keeps the password confirmation helper (`syncPasswordMismatchError`) to disable submission and surface the inline
   reminder until both entries match—preserve this flow when adjusting the form.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -88,11 +88,19 @@
   }
 
   .table-header {
-    @apply hidden grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] items-center gap-4 text-sm font-semibold text-emerald-900/70 md:grid;
+    @apply hidden items-center gap-4 text-sm font-semibold text-emerald-900/70 md:grid;
+    grid-template-columns: var(
+      --table-grid,
+      minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr)
+    );
   }
 
   .table-row {
-    @apply flex flex-col gap-3 rounded-2xl border border-emerald-100 bg-white/70 px-4 py-4 text-sm text-emerald-900 md:grid md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] md:items-center md:gap-4 md:py-3;
+    @apply flex flex-col gap-3 rounded-2xl border border-emerald-100 bg-white/70 px-4 py-4 text-sm text-emerald-900 md:grid md:items-center md:gap-4 md:py-3;
+    grid-template-columns: var(
+      --table-grid,
+      minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr)
+    );
   }
 
   .card-container {

--- a/frontend/src/pages/FormBuilderPage.js
+++ b/frontend/src/pages/FormBuilderPage.js
@@ -45,6 +45,8 @@ function FormBuilderPage() {
   const [creatorFilter, setCreatorFilter] = useState("all");
   const isAdmin = user.role === "admin";
   const isMentor = user.role === "mentor";
+  const adminTableGridTemplate =
+    "minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1.5fr) auto";
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -464,7 +466,8 @@ function FormBuilderPage() {
         {filteredForms.length ? (
           <div className="space-y-3">
             <div
-              className={`${tableHeaderClasses} md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] md:px-4`}
+              className={`${tableHeaderClasses} md:px-4`}
+              style={{ "--table-grid": adminTableGridTemplate }}
             >
               <span>Title</span>
               <span>Visibility</span>
@@ -479,7 +482,8 @@ function FormBuilderPage() {
               return (
                 <div
                   key={form.id}
-                  className={`${tableRowClasses} md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto]`}
+                  className={tableRowClasses}
+                  style={{ "--table-grid": adminTableGridTemplate }}
                 >
                   <div className="space-y-2">
                     <p className="text-base font-semibold text-emerald-900">


### PR DESCRIPTION
## Summary
- teach the table helper classes to read their column template from a shared `--table-grid` CSS variable so headers and rows align
- apply the four-column template on the admin form library grid via the new custom property hook and keep the header padding
- document the override approach in `frontend/AGENTS.md` and record the adjustment in `docs/Wiki.md`

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc4de88e488333809d8277b8743463