### PR TITLE
feat: align admin management tables and add journal oversight

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -12,6 +12,9 @@
   integrity checks remain in place and update the wiki when adjusting these flows.
 - Admin journaler stewardship now lists mentor relationships and allows deleting journaler accounts via `/admin/journalers` and
   `DELETE /admin/journalers/:id`; keep the aggregated mentor metadata accurate and rely on cascading deletes for related data.
+- Admin journal entries are now available through `/admin/journals` and `DELETE /admin/journals/:id`. Keep the shared level
+  validation aligned with `SHARING_LEVELS`, accept lowercase search filters (`q`, `mood`, `mentorId`, etc.), and return mentor
+  aggregates so the frontend can show linkage chips beside each entry.
 - Admin `/forms` responses must continue returning `creatorName` metadata and the `mentees` association array so the frontend can
   surface who built each form and which journalers are linked.
 - Leave the `/forms` creation route restricted to mentors; admins now manage forms without crafting new templates through that

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,4 +1,23 @@
 
+# 2025-10-08
+
+- Let the mentor and journaler admin directories honor a shared `mentorId` focus filter, wiring the new select inputs through
+  `useSearchParams` so deep links from Journals surface the intended guide and the `View journalers` shortcut lands on their
+  linked mentees instantly.
+- Updated mentor cards to pass both `mentorId` and human labels when jumping to Forms or Journalers, and taught the Forms admin
+  table to hydrate from a new `creatorId` query parameter so creator filters stick even when a mentor lacks a display name.
+- Noted the ID-based linking guidance in `frontend/AGENTS.md` to keep future dashboard navigation consistent across the admin
+  stewardship pages.
+
+# 2025-10-07
+
+- Unified the admin stewardship pages by refactoring journaler and mentor directories into the shared table layout, wiring their
+  filters through `useSearchParams`, and adding quick jumps into the new Journals index.
+- Added `frontend/src/pages/JournalAdminPage.js` plus matching backend `/admin/journals` endpoints so admins can search, filter,
+  and delete journal entries while tracing mentor ties directly from the dashboard.
+- Extended the admin forms view to hydrate filters from the query string, letting cross-page "View forms" links land on the
+  intended creator or visibility selection.
+
 # 2025-10-06
 
 - Reworked the admin form library table to drive its column layout through a shared `--table-grid` CSS variable so headers and

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -33,6 +33,16 @@ tays balanced across breakpoints.
 - The shared `table-header` and `table-row` tokens power the responsive admin tables. They collapse into stacked cards on small
   screens and expand to the three-column grid on medium breakpoints—preserve that pattern when listing forms or similar resources.
   Override the column template with the `--table-grid` CSS variable when a layout needs more (or fewer) columns so headers and rows stay aligned.
+- Admin resource tables (journalers, mentors, forms, and journals) now share the same filter mechanics: encode active filters in
+  the query string (`q`, `link`, `sharedLevel`, `mentorId`, etc.), normalize search terms to lowercase before requesting data,
+  and hydrate initial state from `useSearchParams` so cross-page "view journals" or "view forms" links land on a pre-filtered list.
+  Pair every header filter with an `sr-only` label and reuse the `table-header`/`table-row` token grid for consistent responsive
+  behavior.
+- The journaler and mentor admin pages both expose a `mentorId` focus select. Preserve this when updating filters so deep links
+  from the Journals dashboard or mentor cards can highlight a specific guide and keep the `link=linked` context intact.
+- When wiring cross-resource navigation, include ID parameters alongside human labels. For example, the Forms admin view now reads
+  `creatorId` from the query string to hydrate the creator filter even when a mentor has no display name—always pass the id and an
+  optional label when linking from Mentors to Forms.
 - `FormBuilderPage` now leans on the table tokens for admin form stewardship. Keep the four-column medium grid (`title`, `visibility`, `assignments`, `actions`) so delete controls and mentee chips stay aligned with the dashboard's other tables by setting `style={{ "--table-grid": "minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1.5fr) auto" }}` on both the header and each row.
 
 - `RegisterPage` keeps the password confirmation helper (`syncPasswordMismatchError`) to disable submission and surface the inline

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import MentorDashboard from "./pages/MentorDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import MentorConnectionsPage from "./pages/MentorConnectionsPage";
 import JournalerManagementPage from "./pages/JournalerManagementPage";
+import JournalAdminPage from "./pages/JournalAdminPage";
 import JournalHistoryPage from "./pages/JournalHistoryPage";
 import FormBuilderPage from "./pages/FormBuilderPage";
 import SettingsPage from "./pages/SettingsPage";
@@ -97,6 +98,14 @@ function AppRoutes() {
               element={
                 <ProtectedRoute roles={["admin"]}>
                   <JournalerManagementPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/journals"
+              element={
+                <ProtectedRoute roles={["admin"]}>
+                  <JournalAdminPage />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -29,6 +29,7 @@ const roleNavigation = {
   admin: [
     { to: "/dashboard", label: "Dashboard" },
     { to: "/journalers", label: "Journaler" },
+    { to: "/journals", label: "Journals" },
     { to: "/mentorship", label: "Mentors" },
     { to: "/forms", label: "Forms" },
     { to: "/settings", label: "Settings" },

--- a/frontend/src/pages/JournalAdminPage.js
+++ b/frontend/src/pages/JournalAdminPage.js
@@ -1,0 +1,586 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import apiClient from "../api/client";
+import LoadingState from "../components/LoadingState";
+import SectionCard from "../components/SectionCard";
+import { useAuth } from "../context/AuthContext";
+import {
+  chipBaseClasses,
+  dangerButtonClasses,
+  emptyStateClasses,
+  infoTextClasses,
+  inputCompactClasses,
+  mutedTextClasses,
+  secondaryButtonClasses,
+  selectCompactClasses,
+  subtleButtonClasses,
+  tableHeaderClasses,
+  tableRowClasses,
+} from "../styles/ui";
+
+const SHARED_LEVEL_OPTIONS = ["all", "private", "mood", "summary", "full"];
+
+const sharedLevelSet = new Set(SHARED_LEVEL_OPTIONS);
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: "medium" });
+
+function formatDateTime(value) {
+  if (!value) {
+    return "—";
+  }
+
+  try {
+    return dateTimeFormatter.format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function formatDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return dateFormatter.format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function JournalAdminPage() {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const paramsString = searchParams.toString();
+
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [searchTerm, setSearchTerm] = useState(() => searchParams.get("q") || "");
+  const [sharedLevelFilter, setSharedLevelFilter] = useState(() => {
+    const param = searchParams.get("sharedLevel") || "all";
+    return sharedLevelSet.has(param) ? param : "all";
+  });
+  const [moodFilter, setMoodFilter] = useState(
+    () => searchParams.get("mood") || "all"
+  );
+  const [journalerFilter, setJournalerFilter] = useState(
+    () => searchParams.get("journalerId") || ""
+  );
+  const [mentorFilter, setMentorFilter] = useState(
+    () => searchParams.get("mentorId") || ""
+  );
+
+  useEffect(() => {
+    const nextSearch = searchParams.get("q") || "";
+    if (nextSearch !== searchTerm) {
+      setSearchTerm(nextSearch);
+    }
+
+    const sharedParam = searchParams.get("sharedLevel") || "all";
+    const normalizedShared = sharedLevelSet.has(sharedParam)
+      ? sharedParam
+      : "all";
+    if (normalizedShared !== sharedLevelFilter) {
+      setSharedLevelFilter(normalizedShared);
+    }
+
+    const nextMood = searchParams.get("mood") || "all";
+    if (nextMood !== moodFilter) {
+      setMoodFilter(nextMood);
+    }
+
+    const nextJournaler = searchParams.get("journalerId") || "";
+    if (nextJournaler !== journalerFilter) {
+      setJournalerFilter(nextJournaler);
+    }
+
+    const nextMentor = searchParams.get("mentorId") || "";
+    if (nextMentor !== mentorFilter) {
+      setMentorFilter(nextMentor);
+    }
+  }, [journalerFilter, mentorFilter, moodFilter, paramsString, searchParams, searchTerm, sharedLevelFilter]);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    let isActive = true;
+
+    const loadEntries = async () => {
+      setLoading(true);
+      try {
+        const query = paramsString ? `?${paramsString}` : "";
+        const res = await apiClient.get(`/admin/journals${query}`, token);
+
+        if (!isActive) {
+          return;
+        }
+
+        setEntries(res.entries || []);
+        setMessage(null);
+      } catch (error) {
+        if (isActive) {
+          setMessage(error.message);
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadEntries();
+
+    return () => {
+      isActive = false;
+    };
+  }, [paramsString, reloadKey, token]);
+
+  const applyFilters = useCallback(
+    (overrides = {}) => {
+      const normalizedSearch = (overrides.searchTerm ?? searchTerm)
+        .trim()
+        .toLowerCase();
+      const nextShared = overrides.sharedLevel ?? sharedLevelFilter;
+      const nextMood = overrides.mood ?? moodFilter;
+      const nextJournaler = overrides.journaler ?? journalerFilter;
+      const nextMentor = overrides.mentor ?? mentorFilter;
+
+      const nextParams = new URLSearchParams();
+
+      if (normalizedSearch) {
+        nextParams.set("q", normalizedSearch);
+      }
+
+      if (nextShared && nextShared !== "all") {
+        nextParams.set("sharedLevel", nextShared);
+      }
+
+      if (nextMood && nextMood !== "all") {
+        nextParams.set("mood", nextMood);
+      }
+
+      if (nextJournaler) {
+        nextParams.set("journalerId", nextJournaler);
+      }
+
+      if (nextMentor) {
+        nextParams.set("mentorId", nextMentor);
+      }
+
+      const nextString = nextParams.toString();
+      if (nextString !== paramsString) {
+        setSearchParams(nextParams);
+      }
+    },
+    [
+      journalerFilter,
+      mentorFilter,
+      moodFilter,
+      paramsString,
+      searchTerm,
+      setSearchParams,
+      sharedLevelFilter,
+    ]
+  );
+
+  const handleFilterSubmit = (event) => {
+    event.preventDefault();
+    applyFilters();
+  };
+
+  const handleSharedLevelChange = (value) => {
+    setSharedLevelFilter(value);
+    applyFilters({ sharedLevel: value });
+  };
+
+  const handleMoodChange = (value) => {
+    setMoodFilter(value);
+    applyFilters({ mood: value });
+  };
+
+  const handleJournalerChange = (value) => {
+    setJournalerFilter(value);
+    applyFilters({ journaler: value });
+  };
+
+  const handleMentorChange = (value) => {
+    setMentorFilter(value);
+    applyFilters({ mentor: value });
+  };
+
+  const handleClearFilters = () => {
+    setSearchTerm("");
+    setSharedLevelFilter("all");
+    setMoodFilter("all");
+    setJournalerFilter("");
+    setMentorFilter("");
+    if (paramsString) {
+      setSearchParams({});
+    }
+  };
+
+  const handleDeleteEntry = async (entry) => {
+    const journalerName = entry?.journaler?.name || "this journal";
+    const confirmed = window.confirm(
+      `Remove ${journalerName}'s reflection? This cannot be undone.`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await apiClient.del(`/admin/journals/${entry.id}`, token);
+      setMessage("Journal entry deleted.");
+      setReloadKey((prev) => prev + 1);
+    } catch (error) {
+      setMessage(error.message);
+    }
+  };
+
+  const mentorOptions = useMemo(() => {
+    const map = new Map();
+
+    entries.forEach((entry) => {
+      if (Array.isArray(entry.mentors)) {
+        entry.mentors.forEach((mentor) => {
+          if (!mentor?.id) {
+            return;
+          }
+
+          const key = String(mentor.id);
+          if (!map.has(key)) {
+            map.set(key, mentor.name || mentor.email || `Mentor ${mentor.id}`);
+          }
+        });
+      }
+    });
+
+    if (mentorFilter && !map.has(mentorFilter)) {
+      map.set(mentorFilter, `Mentor ${mentorFilter}`);
+    }
+
+    return Array.from(map.entries())
+      .map(([id, label]) => ({ id, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [entries, mentorFilter]);
+
+  const journalerOptions = useMemo(() => {
+    const map = new Map();
+
+    entries.forEach((entry) => {
+      if (!entry?.journaler?.id) {
+        return;
+      }
+
+      const key = String(entry.journaler.id);
+      if (!map.has(key)) {
+        map.set(
+          key,
+          entry.journaler.name || entry.journaler.email || `Journaler ${key}`
+        );
+      }
+    });
+
+    if (journalerFilter && !map.has(journalerFilter)) {
+      map.set(journalerFilter, `Journaler ${journalerFilter}`);
+    }
+
+    return Array.from(map.entries())
+      .map(([id, label]) => ({ id, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [entries, journalerFilter]);
+
+  const moodOptions = useMemo(() => {
+    const set = new Set();
+
+    entries.forEach((entry) => {
+      if (entry.mood) {
+        set.add(entry.mood);
+      }
+    });
+
+    if (moodFilter && moodFilter !== "all") {
+      set.add(moodFilter);
+    }
+
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [entries, moodFilter]);
+
+  const filtersApplied =
+    (searchTerm || "").trim().length > 0 ||
+    sharedLevelFilter !== "all" ||
+    (moodFilter && moodFilter !== "all") ||
+    Boolean(journalerFilter) ||
+    Boolean(mentorFilter);
+
+  if (loading) {
+    return <LoadingState label="Loading journals" />;
+  }
+
+  const tableGrid =
+    "minmax(0, 1.6fr) minmax(0, 1.6fr) minmax(0, 0.9fr)";
+
+  return (
+    <div className="flex w-full flex-1 flex-col gap-8">
+      {message && <p className={infoTextClasses}>{message}</p>}
+
+      <SectionCard
+        title="Journal library"
+        subtitle="Search reflections, trace mentor ties, and retire entries that need to rest"
+        action={
+          <form
+            className="flex flex-wrap items-center gap-3"
+            onSubmit={handleFilterSubmit}
+          >
+            <label className="sr-only" htmlFor="journal-search">
+              Search journals
+            </label>
+            <input
+              id="journal-search"
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search by journaler, mentor, form, or summary"
+              className={`${inputCompactClasses} w-full sm:w-64`}
+            />
+            <label className="sr-only" htmlFor="journal-shared-filter">
+              Filter by sharing level
+            </label>
+            <select
+              id="journal-shared-filter"
+              className={`${selectCompactClasses} w-full sm:w-44`}
+              value={sharedLevelFilter}
+              onChange={(event) => handleSharedLevelChange(event.target.value)}
+            >
+              {SHARED_LEVEL_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option === "all" ? "All sharing" : option}
+                </option>
+              ))}
+            </select>
+            <label className="sr-only" htmlFor="journal-mood-filter">
+              Filter by mood
+            </label>
+            <select
+              id="journal-mood-filter"
+              className={`${selectCompactClasses} w-full sm:w-44`}
+              value={moodFilter}
+              onChange={(event) => handleMoodChange(event.target.value)}
+            >
+              <option value="all">All moods</option>
+              {moodOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+            <label className="sr-only" htmlFor="journal-journaler-filter">
+              Filter by journaler
+            </label>
+            <select
+              id="journal-journaler-filter"
+              className={`${selectCompactClasses} w-full sm:w-44`}
+              value={journalerFilter}
+              onChange={(event) => handleJournalerChange(event.target.value)}
+            >
+              <option value="">All journalers</option>
+              {journalerOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <label className="sr-only" htmlFor="journal-mentor-filter">
+              Filter by mentor
+            </label>
+            <select
+              id="journal-mentor-filter"
+              className={`${selectCompactClasses} w-full sm:w-44`}
+              value={mentorFilter}
+              onChange={(event) => handleMentorChange(event.target.value)}
+            >
+              <option value="">All mentors</option>
+              {mentorOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+            >
+              Apply filters
+            </button>
+            <button
+              type="button"
+              className={`${subtleButtonClasses} px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60`}
+              onClick={handleClearFilters}
+              disabled={!filtersApplied}
+            >
+              Clear filters
+            </button>
+          </form>
+        }
+      >
+        {entries.length ? (
+          <div className="space-y-3">
+            <div
+              className={`${tableHeaderClasses} md:px-4`}
+              style={{ "--table-grid": tableGrid }}
+            >
+              <span>Journaler</span>
+              <span>Reflection</span>
+              <span className="md:text-right">Actions</span>
+            </div>
+            {entries.map((entry) => {
+              const mentorList = Array.isArray(entry.mentors)
+                ? entry.mentors.filter((mentor) => mentor && mentor.id)
+                : [];
+
+              const createdLabel = formatDateTime(entry.createdAt);
+              const entryDateLabel = formatDate(entry.entryDate);
+
+              return (
+                <div
+                  key={entry.id}
+                  className={tableRowClasses}
+                  style={{ "--table-grid": tableGrid }}
+                >
+                  <div className="space-y-2">
+                    <p className="text-base font-semibold text-emerald-900">
+                      {entry.journaler?.name || entry.journaler?.email || "Journaler"}
+                    </p>
+                    {entry.journaler?.email && (
+                      <p className={infoTextClasses}>{entry.journaler.email}</p>
+                    )}
+                    <p className={`${mutedTextClasses} text-sm`}>
+                      Logged {createdLabel}
+                    </p>
+                    {entryDateLabel && (
+                      <p className={`${mutedTextClasses} text-sm`}>
+                        Reflecting on {entryDateLabel}
+                      </p>
+                    )}
+                  </div>
+                  <div className="space-y-3">
+                    <div className="space-y-1">
+                      {entry.form ? (
+                        <p className="text-sm font-semibold text-emerald-900">
+                          Form: {entry.form.title}
+                        </p>
+                      ) : (
+                        <p className={`${mutedTextClasses} text-sm`}>
+                          Form removed
+                        </p>
+                      )}
+                      <div className="flex flex-wrap gap-2">
+                        <span className={chipBaseClasses}>
+                          Shared: {entry.sharedLevel}
+                        </span>
+                        {entry.mood && (
+                          <span className={chipBaseClasses}>Mood: {entry.mood}</span>
+                        )}
+                      </div>
+                    </div>
+                    {entry.summary && (
+                      <p className={`${mutedTextClasses} text-sm`}>
+                        {entry.summary}
+                      </p>
+                    )}
+                    <div className="space-y-2">
+                      <p className={`${mutedTextClasses} text-xs uppercase tracking-wide`}>
+                        Linked mentors
+                      </p>
+                      {mentorList.length ? (
+                        <ul className="flex flex-wrap gap-2">
+                          {mentorList.map((mentor) => (
+                            <li key={mentor.id} className="flex items-center gap-2">
+                              <span className={chipBaseClasses}>
+                                {mentor.name || mentor.email || `Mentor ${mentor.id}`}
+                              </span>
+                              <button
+                                type="button"
+                                className={`${subtleButtonClasses} px-3 py-1 text-xs`}
+                                onClick={() => {
+                                  const params = new URLSearchParams();
+                                  params.set("link", "linked");
+
+                                  if (mentor?.id) {
+                                    params.set("mentorId", String(mentor.id));
+                                  }
+
+                                  const mentorQuery =
+                                    mentor.email || mentor.name || "";
+                                  if (mentorQuery) {
+                                    params.set(
+                                      "q",
+                                      mentorQuery.toLowerCase()
+                                    );
+                                  }
+
+                                  navigate(`/mentorship?${params.toString()}`);
+                                }}
+                              >
+                                View mentor
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className={`${mutedTextClasses} text-sm`}>
+                          No mentors linked.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-2 md:items-end">
+                    <button
+                      type="button"
+                      className={`${secondaryButtonClasses} w-full px-4 py-2 text-sm md:w-auto`}
+                      onClick={() => {
+                        const journalerQuery = (
+                          entry.journaler?.email || entry.journaler?.name || ""
+                        )
+                          .toLowerCase()
+                          .trim();
+                        const queryString = journalerQuery
+                          ? `?q=${encodeURIComponent(journalerQuery)}`
+                          : "";
+                        navigate(`/journalers${queryString}`);
+                      }}
+                    >
+                      View journaler
+                    </button>
+                    <button
+                      type="button"
+                      className={`${dangerButtonClasses} w-full px-4 py-2 text-sm md:w-auto`}
+                      onClick={() => handleDeleteEntry(entry)}
+                    >
+                      Delete journal
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className={emptyStateClasses}>No journal entries match those filters.</p>
+        )}
+      </SectionCard>
+    </div>
+  );
+}
+
+export default JournalAdminPage;

--- a/frontend/src/pages/JournalerManagementPage.js
+++ b/frontend/src/pages/JournalerManagementPage.js
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import apiClient from "../api/client";
 import LoadingState from "../components/LoadingState";
 import SectionCard from "../components/SectionCard";
@@ -9,17 +10,67 @@ import {
   emptyStateClasses,
   infoTextClasses,
   inputCompactClasses,
+  mutedTextClasses,
   secondaryButtonClasses,
+  selectCompactClasses,
+  subtleButtonClasses,
+  tableHeaderClasses,
+  tableRowClasses,
 } from "../styles/ui";
 
 function JournalerManagementPage() {
   const { token } = useAuth();
   const [journalers, setJournalers] = useState([]);
-  const [journalerSearch, setJournalerSearch] = useState("");
-  const [journalerQuery, setJournalerQuery] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const paramsString = searchParams.toString();
+  const navigate = useNavigate();
+  const [journalerSearch, setJournalerSearch] = useState(
+    () => searchParams.get("q") || ""
+  );
+  const [journalerQuery, setJournalerQuery] = useState(
+    () => searchParams.get("q") || ""
+  );
+  const [mentorFilter, setMentorFilter] = useState(
+    () => searchParams.get("mentorId") || ""
+  );
+  const [linkFilter, setLinkFilter] = useState(() => {
+    const param = searchParams.get("link");
+    return param === "linked" || param === "unlinked" ? param : "all";
+  });
   const [reloadKey, setReloadKey] = useState(0);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState(null);
+
+  useEffect(() => {
+    const nextQuery = searchParams.get("q") || "";
+    if (nextQuery !== journalerQuery) {
+      setJournalerQuery(nextQuery);
+    }
+
+    if (nextQuery !== journalerSearch) {
+      setJournalerSearch(nextQuery);
+    }
+
+    const nextLink = searchParams.get("link");
+    const normalizedLink =
+      nextLink === "linked" || nextLink === "unlinked" ? nextLink : "all";
+
+    if (normalizedLink !== linkFilter) {
+      setLinkFilter(normalizedLink);
+    }
+
+    const nextMentor = searchParams.get("mentorId") || "";
+    if (nextMentor !== mentorFilter) {
+      setMentorFilter(nextMentor);
+    }
+  }, [
+    journalerQuery,
+    journalerSearch,
+    linkFilter,
+    mentorFilter,
+    paramsString,
+    searchParams,
+  ]);
 
   useEffect(() => {
     if (!token) {
@@ -63,7 +114,74 @@ function JournalerManagementPage() {
 
   const handleJournalerSearch = (event) => {
     event.preventDefault();
-    setJournalerQuery(journalerSearch.trim().toLowerCase());
+    const normalized = journalerSearch.trim().toLowerCase();
+    const nextParams = new URLSearchParams();
+
+    if (normalized) {
+      nextParams.set("q", normalized);
+    }
+
+    if (linkFilter !== "all") {
+      nextParams.set("link", linkFilter);
+    }
+
+    if (mentorFilter) {
+      nextParams.set("mentorId", mentorFilter);
+    }
+
+    setSearchParams(nextParams);
+  };
+
+  const handleLinkFilterChange = (value) => {
+    const normalized = value === "linked" || value === "unlinked" ? value : "all";
+    setLinkFilter(normalized);
+
+    const nextParams = new URLSearchParams();
+
+    if (journalerQuery) {
+      nextParams.set("q", journalerQuery);
+    }
+
+    if (normalized !== "all") {
+      nextParams.set("link", normalized);
+    }
+
+    if (mentorFilter) {
+      nextParams.set("mentorId", mentorFilter);
+    }
+
+    setSearchParams(nextParams);
+  };
+
+  const handleMentorFilterChange = (value) => {
+    const normalized = value || "";
+    setMentorFilter(normalized);
+
+    const nextParams = new URLSearchParams();
+
+    if (journalerQuery) {
+      nextParams.set("q", journalerQuery);
+    }
+
+    if (linkFilter !== "all") {
+      nextParams.set("link", linkFilter);
+    }
+
+    if (normalized) {
+      nextParams.set("mentorId", normalized);
+    }
+
+    setSearchParams(nextParams);
+  };
+
+  const handleClearFilters = () => {
+    setJournalerSearch("");
+    setJournalerQuery("");
+    setLinkFilter("all");
+    setMentorFilter("");
+    if (paramsString) {
+      setSearchParams({});
+    }
   };
 
   const unlinkMentor = async (mentorId, journaler) => {
@@ -94,9 +212,74 @@ function JournalerManagementPage() {
     }
   };
 
+  const mentorOptions = useMemo(() => {
+    const map = new Map();
+
+    journalers.forEach((journaler) => {
+      if (!Array.isArray(journaler.mentors)) {
+        return;
+      }
+
+      journaler.mentors.forEach((mentor) => {
+        if (!mentor?.id) {
+          return;
+        }
+
+        const key = String(mentor.id);
+        if (!map.has(key)) {
+          map.set(key, mentor.name || mentor.email || `Mentor ${key}`);
+        }
+      });
+    });
+
+    if (mentorFilter && !map.has(mentorFilter)) {
+      map.set(mentorFilter, `Mentor ${mentorFilter}`);
+    }
+
+    return Array.from(map.entries())
+      .map(([id, label]) => ({ id, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [journalers, mentorFilter]);
+
+  const filteredJournalers = useMemo(() => {
+    return journalers.filter((journaler) => {
+      const mentorCount = Number.parseInt(journaler.mentor_count, 10) || 0;
+      const mentorsList = Array.isArray(journaler.mentors)
+        ? journaler.mentors
+        : [];
+
+      if (mentorFilter) {
+        const hasMentor = mentorsList.some(
+          (mentor) => String(mentor?.id) === mentorFilter
+        );
+
+        if (!hasMentor) {
+          return false;
+        }
+      }
+
+      if (linkFilter === "linked") {
+        return mentorCount > 0;
+      }
+
+      if (linkFilter === "unlinked") {
+        return mentorCount === 0;
+      }
+
+      return true;
+    });
+  }, [journalers, linkFilter, mentorFilter]);
+
+  const filtersApplied =
+    (journalerQuery || "").trim().length > 0 ||
+    linkFilter !== "all" ||
+    Boolean(mentorFilter);
+
   if (loading) {
     return <LoadingState label="Loading journalers" />;
   }
+
+  const tableGrid = "minmax(0, 1.6fr) minmax(0, 1.4fr) minmax(0, 0.8fr)";
 
   return (
     <div className="flex w-full flex-1 flex-col gap-8">
@@ -106,82 +289,158 @@ function JournalerManagementPage() {
         subtitle="Shepherd every journaler's journey, review their mentor ties, and gently close accounts that need to rest"
         action={
           <form className="flex flex-wrap items-center gap-3" onSubmit={handleJournalerSearch}>
+            <label className="sr-only" htmlFor="journaler-search">
+              Search journalers
+            </label>
             <input
+              id="journaler-search"
               type="search"
               placeholder="Search by name or email"
               value={journalerSearch}
               onChange={(event) => setJournalerSearch(event.target.value)}
-              className={`${inputCompactClasses} w-full sm:w-72`}
+              className={`${inputCompactClasses} w-full sm:w-64`}
             />
+            <label className="sr-only" htmlFor="journaler-link-filter">
+              Filter by mentor connections
+            </label>
+            <select
+              id="journaler-link-filter"
+              className={`${selectCompactClasses} w-full sm:w-48`}
+              value={linkFilter}
+              onChange={(event) => handleLinkFilterChange(event.target.value)}
+            >
+              <option value="all">All journalers</option>
+              <option value="linked">Linked to mentors</option>
+              <option value="unlinked">Waiting for mentors</option>
+            </select>
+            <label className="sr-only" htmlFor="journaler-mentor-filter">
+              Focus on mentor
+            </label>
+            <select
+              id="journaler-mentor-filter"
+              className={`${selectCompactClasses} w-full sm:w-48`}
+              value={mentorFilter}
+              onChange={(event) => handleMentorFilterChange(event.target.value)}
+            >
+              <option value="">All mentors</option>
+              {mentorOptions.map((mentor) => (
+                <option key={mentor.id} value={mentor.id}>
+                  {mentor.label}
+                </option>
+              ))}
+            </select>
             <button type="submit" className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}>
-              Search journalers
+              Apply search
+            </button>
+            <button
+              type="button"
+              className={`${subtleButtonClasses} px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60`}
+              onClick={handleClearFilters}
+              disabled={!filtersApplied}
+            >
+              Clear filters
             </button>
           </form>
         }
       >
-        {journalers.length ? (
-          <ul className="space-y-6">
-            {journalers.map((journaler) => {
-              const mentorList = Array.isArray(journaler.mentors) ? journaler.mentors : [];
+        {filteredJournalers.length ? (
+          <div className="space-y-3">
+            <div
+              className={`${tableHeaderClasses} md:px-4`}
+              style={{ "--table-grid": tableGrid }}
+            >
+              <span>Journaler</span>
+              <span>Mentor connections</span>
+              <span className="md:text-right">Actions</span>
+            </div>
+            {filteredJournalers.map((journaler) => {
+              const mentorList = Array.isArray(journaler.mentors)
+                ? journaler.mentors.filter((mentor) => mentor && mentor.id)
+                : [];
+              const mentorCount = Number.parseInt(journaler.mentor_count, 10) || 0;
 
               return (
-                <li key={journaler.id} className="rounded-2xl border border-emerald-100 bg-white/70 p-5">
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="space-y-2">
-                      <p className="text-base font-semibold text-emerald-900">{journaler.name}</p>
+                <div
+                  key={journaler.id}
+                  className={tableRowClasses}
+                  style={{ "--table-grid": tableGrid }}
+                >
+                  <div className="space-y-2">
+                    <p className="text-base font-semibold text-emerald-900">
+                      {journaler.name || journaler.email}
+                    </p>
+                    {journaler.email && (
                       <p className={infoTextClasses}>{journaler.email}</p>
-                    </div>
-                    <div className="flex flex-col gap-3 lg:w-1/2">
-                      <div className="rounded-xl border border-emerald-100 bg-emerald-50/60 p-4">
-                        <p className={`${infoTextClasses} mb-3 font-semibold text-emerald-900`}>
-                          Linked mentors
-                        </p>
-                        {mentorList.length ? (
-                          <ul className="space-y-2">
-                            {mentorList.map((mentor) => (
-                              <li
-                                key={mentor.id}
-                                className="flex flex-col gap-2 rounded-lg bg-white/80 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
-                              >
-                                <div>
-                                  <p className="text-sm font-semibold text-emerald-900">{mentor.name || "Mentor"}</p>
-                                  <p className={`${captionTextClasses} text-emerald-900/70`}>{mentor.email}</p>
-                                </div>
-                                <button
-                                  type="button"
-                                  className={`${secondaryButtonClasses} px-3 py-1 text-xs`}
-                                  onClick={() =>
-                                    unlinkMentor(mentor.id, {
-                                      id: journaler.id,
-                                      name: journaler.name,
-                                      email: journaler.email,
-                                    })
-                                  }
-                                >
-                                  Unlink mentor
-                                </button>
-                              </li>
-                            ))}
-                          </ul>
-                        ) : (
-                          <p className={infoTextClasses}>Not yet connected to a mentor.</p>
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        className={`${dangerButtonClasses} self-start px-4 py-2 text-sm`}
-                        onClick={() => deleteJournaler(journaler)}
-                      >
-                        Delete journaler
-                      </button>
-                    </div>
+                    )}
+                    <p className={`${mutedTextClasses} text-sm`}>
+                      {mentorCount} mentor{mentorCount === 1 ? "" : "s"} linked
+                    </p>
                   </div>
-                </li>
+                  <div className="space-y-3">
+                    <p className={`${mutedTextClasses} text-xs uppercase tracking-wide`}>
+                      Linked mentors
+                    </p>
+                    {mentorList.length ? (
+                      <ul className="space-y-2">
+                        {mentorList.map((mentor) => (
+                          <li
+                            key={mentor.id}
+                            className="flex flex-col gap-2 rounded-xl bg-white/70 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                          >
+                            <div>
+                              <p className="text-sm font-semibold text-emerald-900">
+                                {mentor.name || "Mentor"}
+                              </p>
+                              {mentor.email && (
+                                <p className={`${captionTextClasses} text-emerald-900/70`}>
+                                  {mentor.email}
+                                </p>
+                              )}
+                            </div>
+                            <button
+                              type="button"
+                              className={`${subtleButtonClasses} px-3 py-1 text-xs`}
+                              onClick={() =>
+                                unlinkMentor(mentor.id, {
+                                  id: journaler.id,
+                                  name: journaler.name,
+                                  email: journaler.email,
+                                })
+                              }
+                            >
+                              Unlink mentor
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className={`${mutedTextClasses} text-sm`}>
+                        Not yet connected to a mentor.
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-2 md:items-end">
+                    <button
+                      type="button"
+                      className={`${secondaryButtonClasses} w-full px-4 py-2 text-sm md:w-auto`}
+                      onClick={() => navigate(`/journals?journalerId=${journaler.id}`)}
+                    >
+                      View journals
+                    </button>
+                    <button
+                      type="button"
+                      className={`${dangerButtonClasses} w-full px-4 py-2 text-sm md:w-auto`}
+                      onClick={() => deleteJournaler(journaler)}
+                    >
+                      Delete journaler
+                    </button>
+                  </div>
+                </div>
               );
             })}
-          </ul>
+          </div>
         ) : (
-          <p className={emptyStateClasses}>No journalers found.</p>
+          <p className={emptyStateClasses}>No journalers match those filters.</p>
         )}
       </SectionCard>
     </div>


### PR DESCRIPTION
## Summary
- add `/admin/journals` endpoints plus a dedicated admin page to search, filter, and delete entries while surfacing mentor links
- refactor the admin journaler and mentor directories into the shared responsive table layout with querystring-driven filters
- hydrate the form builder filters from URL params and document the unified admin table pattern

## Testing
- npm run build
- node --check backend/routes/admin.js

------
https://chatgpt.com/codex/tasks/task_e_68cc5adeb3c48333adfe05cd763e13de