### PR TITLE
Document README feature coverage

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,5 @@
+# Docs Agent Notes
+
+- Document any repository review or knowledge-base updates in `docs/Wiki.md` so the history stays chronological.
+- When introducing new documentation under `docs/`, include actionable summaries and reference the underlying code when possible.
+- Keep `docs/features.md` current whenever feature availability changes.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# 2025-10-09
+
+- Documented the implemented and missing README features in `docs/features.md`, noting reminder and mentor notification gaps plus the broken panic alert flow.
+- Added `docs/AGENTS.md` to guide future documentation updates within the knowledge base.
+
 
 # 2025-10-08
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,55 @@
+# Feature Review
+
+## Journal entry forms
+Feature Name: Journal entry forms
+Present: Yes
+Implemented: Fully
+Code Quality: Good
+Notes:
+- Backend routes expose default retrieval, role-based listings, creation, and assignments with strong validation and transactional inserts.【F:backend/routes/forms.js†L1-L207】【F:frontend/src/pages/FormBuilderPage.js†L1-L120】
+
+## Authentication
+Feature Name: Authentication
+Present: Yes
+Implemented: Fully
+Code Quality: Good
+Notes:
+- Registration, verification, login, and profile hydration flows include JWT issuance and mentor profile support, backed by reusable email templating.【F:backend/routes/auth.js†L1-L200】【F:backend/utils/emailTemplates.js†L1-L120】
+
+## Mentor linking
+Feature Name: Mentor linking
+Present: Yes
+Implemented: Fully
+Code Quality: Good
+Notes:
+- Mentor search, request, acceptance, confirmation, and unlinking endpoints enforce role checks and manage mentorship records atomically.【F:backend/routes/mentors.js†L29-L376】
+
+## Reminders
+Feature Name: Reminders
+Present: No
+Tasks:
+- Task 1: Implement a backend scheduler to send daily/weekly reminder emails honoring user preferences (Complexity: High).
+- Task 2: Restore a settings interface so journalers can opt into reminder cadences (Complexity: Medium).【F:README.md†L28-L33】【49301e†L1-L12】
+
+## Mentor notifications
+Feature Name: Mentor notifications
+Present: No
+Tasks:
+- Task 1: Add notification dispatch when journal entries are created respecting share levels (Complexity: High).
+- Task 2: Create digest templates and delivery jobs for mentor summaries (Complexity: Medium).【F:README.md†L34-L36】【8a8581†L1-L7】
+
+## Panic support alerts
+Feature Name: Panic support alerts
+Present: Yes
+Implemented: Partially
+Code Quality: Ugly
+Notes:
+- The SOS button is exposed only to journalers in the client while the server restricts `/mentors/panic-alerts` to mentors and never sends the intended escalation email, leaving the flow inconsistent and inert.【F:frontend/src/components/PanicButton.js†L13-L199】【F:backend/routes/mentors.js†L383-L445】
+
+## Dashboards
+Feature Name: Dashboards
+Present: Yes
+Implemented: Fully
+Code Quality: Good
+Notes:
+- Journaler and mentor dashboards aggregate streaks, mood trends, alerts, and mentee activity with reusable metrics helpers and optimized queries.【F:backend/routes/dashboard.js†L1-L234】【F:frontend/src/pages/JournalerDashboard.js†L1-L120】


### PR DESCRIPTION
## Summary
- capture the implementation status of the README core features in a new docs/features.md report
- note the missing reminder and mentor notification flows and the broken panic alert pathway
- add docs/AGENTS.md guidance and log the documentation update in docs/Wiki.md

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc69acec908333b5a9dc3e5e93aecd