### PR TITLE
Remove reminder feature references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Aleya is a journaling and mentorship platform that pairs reflective journaling t
 - **Journal entry forms:** A collection of customizable forms rather than a single template. The default form captures mood (happy, loved, proud, relaxed, tired, anxious, angry, sad), the causes of today's emotions, and learnings. Optional fields include sleep, energy, and activities. Mentors can assign additional or specialised forms after both parties confirm the mentorship link.
 - **Authentication:** Email + password with email verification.
 - **Mentor linking:** Journalers can invite or select mentors, forming a mentorship connection only after mutual consent.
-- **Reminders:** Daily or weekly reminders delivered via email.
 - **Mentor notifications:** Email summaries of mentee entries with privacy controls to respect journaler choices.
 - **Panic support alerts:** A persistent panic button lets mentors escalate concerns to their own linked mentors with an urgent note, triggering an "important" email.
 - **Dashboards:** Role-specific dashboards showing streaks, average mood, trendlines, progress overviews, mentee highlights, and low-mood alerts.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# 2025-10-11
+
+- Retired the README reference to email reminders now that the cadence controls remain out of scope, and removed the dormant
+  backlog entry from `docs/features.md` to keep the feature review aligned with the current product story.
+
 # 2025-10-10
 
 - Reintroduced share-aware mentor email notifications that trigger after journal entry creation by wiring `dispatchEntryNotifications`

--- a/docs/features.md
+++ b/docs/features.md
@@ -24,13 +24,6 @@ Code Quality: Good
 Notes:
 - Mentor search, request, acceptance, confirmation, and unlinking endpoints enforce role checks and manage mentorship records atomically.【F:backend/routes/mentors.js†L29-L376】
 
-## Reminders
-Feature Name: Reminders
-Present: No
-Tasks:
-- Task 1: Implement a backend scheduler to send daily/weekly reminder emails honoring user preferences (Complexity: High).
-- Task 2: Restore a settings interface so journalers can opt into reminder cadences (Complexity: Medium).【F:README.md†L28-L33】【49301e†L1-L12】
-
 ## Mentor notifications
 Feature Name: Mentor notifications
 Present: Yes


### PR DESCRIPTION
## Summary
- remove the reminder bullet from the README so the product overview reflects the current feature set
- prune the reminder backlog entry from docs/features.md and document the retirement in docs/Wiki.md

## Testing
- not run (docs only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc7537f65c83338520bce77d0a2f34