### PR TITLE
Refine mobile header navigation overlay

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,9 @@
+# 2025-10-14
+
+- Reimagined the authenticated mobile header so the sticky bar keeps a slender profile while the navigation opens as a floating
+  tray beneath it, keeping the main content visible. Captured the overlay guidance in `frontend/AGENTS.md` for future frontend
+  updates.
+
 # 2025-10-13
 
 - Documented the frontend and backend package suites plus the platform's custom functionality highlights in `README.md` so new contributors can quickly see the tooling stack and advanced flows beyond static pages.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -20,6 +20,9 @@ tays balanced across breakpoints.
   a clear escape hatch.
 - Keep modal headers in a single flex container that houses both the title block and the close button so the markup stays
   balanced and easier to maintain.
+- The authenticated mobile header now keeps its height trim; the navigation tray floats beneath the sticky bar as an overlay.
+  When adjusting mobile navigation, preserve the compact header padding and reuse the floating tray pattern (`absolute top-full`
+  container with rounded borders, blur, and `shadow-xl`) so the main content retains vertical space.
 - Settings now focus on profile essentials: the email reminder fields and in-app notification preferences have been retired for
   every role, so keep the layout lean and avoid reintroducing NotificationContext or bell-style components.
 - Admin mentor management lives on `/mentorship`: show mentor cards with linked mentees, allow linking by email, and surface a

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -125,9 +125,9 @@ function Layout({ children }) {
 
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-br from-emerald-50 via-white to-emerald-100 text-emerald-950">
-      <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/80 backdrop-blur">
-        <div className="mx-auto w-full max-w-6xl px-6 py-4">
-          <div className="flex items-center gap-4">
+      <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/85 backdrop-blur">
+        <div className="relative mx-auto w-full max-w-6xl px-6 py-3">
+          <div className="flex w-full items-center gap-3">
             <button
               type="button"
               className={`rounded-full border border-transparent bg-transparent leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${largeHeadingClasses}`}
@@ -136,7 +136,7 @@ function Layout({ children }) {
               Aleya
             </button>
             <nav
-              className={`hidden flex-1 items-center justify-center gap-2 md:flex ${bodySmallStrongTextClasses} text-emerald-900/70`}
+              className={`hidden flex-1 items-center justify-center gap-1 md:flex ${bodySmallStrongTextClasses} text-emerald-900/70`}
             >
               {links.map((link) => (
                 <NavLink
@@ -201,30 +201,34 @@ function Layout({ children }) {
             </div>
           </div>
           {isMobileMenuOpen && (
-            <div className="mt-4 flex flex-col gap-4 md:hidden" id="mobile-navigation">
-              {links.length > 0 && (
-                <nav
-                  className={`flex flex-col gap-2 ${bodySmallStrongTextClasses} text-emerald-900/80`}
-                >
-                  {links.map((link) => (
-                    <NavLink
-                      key={link.to}
-                      to={link.to}
-                      className={({ isActive }) =>
-                        `rounded-full px-4 py-2 transition ${
-                          isActive
-                            ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
-                            : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
-                        }`
-                      }
-                      onClick={closeMobileMenu}
-                    >
-                      {link.label}
-                    </NavLink>
-                  ))}
-                </nav>
-              )}
-              <AuthControls orientation="vertical" onNavigate={closeMobileMenu} />
+            <div className="absolute left-0 right-0 top-full mt-3 md:hidden" id="mobile-navigation">
+              <div className="rounded-3xl border border-emerald-100 bg-white/95 p-4 shadow-xl shadow-emerald-900/10 backdrop-blur">
+                {links.length > 0 && (
+                  <nav
+                    className={`flex flex-col gap-2 ${bodySmallStrongTextClasses} text-emerald-900/80`}
+                  >
+                    {links.map((link) => (
+                      <NavLink
+                        key={link.to}
+                        to={link.to}
+                        className={({ isActive }) =>
+                          `rounded-full px-4 py-2 transition ${
+                            isActive
+                              ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
+                              : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
+                          }`
+                        }
+                        onClick={closeMobileMenu}
+                      >
+                        {link.label}
+                      </NavLink>
+                    ))}
+                  </nav>
+                )}
+                <div className="mt-4 border-t border-emerald-100/70 pt-4">
+                  <AuthControls orientation="vertical" onNavigate={closeMobileMenu} />
+                </div>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- shrink the sticky header padding on mobile and render the navigation as a floating overlay tray so content keeps more vertical room
- capture the compact mobile navigation pattern in `frontend/AGENTS.md`
- log the responsive header refresh in `docs/Wiki.md`

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cccf1bdfb88333be4a0bf80241f145