### PR TITLE
Fix backend Docker entrypoint resolution

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -12,6 +12,8 @@
   same helpers—when changing time windows, honour the `MENTOR_DIGEST_WINDOW_HOURS` env and keep the job script
   (`jobs/sendMentorDigest.js`) aligned.
 - Double-check route definitions end with their closing `);` pair so `node --check` passes before pushing changes.
+- Docker-compose now binds nodemon to the repository root `index.js` shim. When adjusting the entrypoint, keep that shim requiring
+  `src/index.js` so local development and containers stay aligned.
 - When touching the admin form management endpoints, keep the default template protections intact so system templates are never
   deleted by mistake.
 - Admin mentor management now includes routes for linking/unlinking journalers and deleting mentors; ensure mentor/journaler

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,1 @@
+require("./src/index");

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# 2025-10-15
+
+- Added a root `backend/index.js` shim so Docker and nodemon resolve the backend entrypoint consistently now that the actual
+  server lives in `src/index.js`, and documented the expectation in `backend/AGENTS.md` for future updates.
+
 # 2025-10-14
 
 - Reorganized the backend into `src/` and `tests/`, moved the SQL schema into `backend/docs/`, and added Jest + Prettier + ESLint tooling with CI coverage for format, lint, and unit tests.


### PR DESCRIPTION
## Summary
- add a root backend/index.js shim so Docker and nodemon resolve the server entrypoint correctly
- document the shim requirement in backend/AGENTS.md and note the change in docs/Wiki.md

## Testing
- npm run format:check
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdcd1309188333980b33ffaaa32be4