### PR TITLE
Add default social preview metadata

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,9 +5,38 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <!-- HTML Meta Tags -->
+    <title>Aleya · Grow whole, not in fragments</title>
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Aleya braids reflection, companionship, and gentle accountability so each note of care, habit, and rest can bloom together beneath a steady light."
+    />
+
+    <!-- Facebook Meta Tags -->
+    <meta property="og:url" content="https://aleya.dodon.in" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Aleya · Grow whole, not in fragments" />
+    <meta
+      property="og:description"
+      content="Aleya braids reflection, companionship, and gentle accountability so each note of care, habit, and rest can bloom together beneath a steady light."
+    />
+    <meta
+      property="og:image"
+      content="https://opengraph.b-cdn.net/production/images/f4380101-5605-4121-9237-523a6baf4479.jpg?token=wS88QG0LZOMnH_GWiDo2jNt4zZhdRvpZKYAT0xHcdyE&amp;height=800&amp;width=1200&amp;expires=33294371700"
+    />
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="twitter:domain" content="aleya.dodon.in" />
+    <meta property="twitter:url" content="https://aleya.dodon.in" />
+    <meta name="twitter:title" content="Aleya · Grow whole, not in fragments" />
+    <meta
+      name="twitter:description"
+      content="Aleya braids reflection, companionship, and gentle accountability so each note of care, habit, and rest can bloom together beneath a steady light."
+    />
+    <meta
+      name="twitter:image"
+      content="https://opengraph.b-cdn.net/production/images/f4380101-5605-4121-9237-523a6baf4479.jpg?token=wS88QG0LZOMnH_GWiDo2jNt4zZhdRvpZKYAT0xHcdyE&amp;height=800&amp;width=1200&amp;expires=33294371700"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +53,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Aleya · Grow whole, not in fragments</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { applyDefaultSeo } from "./utils/seo";
+
+applyDefaultSeo();
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(

--- a/frontend/src/utils/seo.js
+++ b/frontend/src/utils/seo.js
@@ -1,0 +1,72 @@
+export const defaultSeoMetadata = {
+  title: "Aleya · Grow whole, not in fragments",
+  description:
+    "Aleya braids reflection, companionship, and gentle accountability so each note of care, habit, and rest can bloom together beneath a steady light.",
+  url: "https://aleya.dodon.in",
+  image:
+    "https://opengraph.b-cdn.net/production/images/f4380101-5605-4121-9237-523a6baf4479.jpg?token=wS88QG0LZOMnH_GWiDo2jNt4zZhdRvpZKYAT0xHcdyE&height=800&width=1200&expires=33294371700",
+  twitterCard: "summary_large_image",
+  twitterDomain: "aleya.dodon.in",
+};
+
+const ensureMetaTag = (attributes, content) => {
+  const selector = Object.entries(attributes)
+    .map(([key, value]) => `[${key}="${value}"]`)
+    .join("");
+
+  let element = document.head.querySelector(`meta${selector}`);
+
+  if (!element) {
+    element = document.createElement("meta");
+    Object.entries(attributes).forEach(([key, value]) => {
+      element.setAttribute(key, value);
+    });
+    document.head.appendChild(element);
+  }
+
+  element.setAttribute("content", content);
+};
+
+export const applyDefaultSeo = () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const { title, description, url, image, twitterCard, twitterDomain } = defaultSeoMetadata;
+
+  if (title) {
+    document.title = title;
+  }
+
+  if (description) {
+    ensureMetaTag({ name: "description" }, description);
+  }
+
+  if (url) {
+    ensureMetaTag({ property: "og:url" }, url);
+    ensureMetaTag({ property: "twitter:url" }, url);
+  }
+
+  if (image) {
+    ensureMetaTag({ property: "og:image" }, image);
+    ensureMetaTag({ name: "twitter:image" }, image);
+  }
+
+  ensureMetaTag({ property: "og:type" }, "website");
+
+  if (title) {
+    ensureMetaTag({ property: "og:title" }, title);
+    ensureMetaTag({ name: "twitter:title" }, title);
+  }
+
+  if (description) {
+    ensureMetaTag({ property: "og:description" }, description);
+    ensureMetaTag({ name: "twitter:description" }, description);
+  }
+
+  ensureMetaTag({ name: "twitter:card" }, twitterCard || "summary_large_image");
+
+  if (twitterDomain) {
+    ensureMetaTag({ property: "twitter:domain" }, twitterDomain);
+  }
+};


### PR DESCRIPTION
## Summary
- add HTML, Open Graph, and Twitter metadata for Aleya's social previews
- capture the default SEO metadata in a shared helper and apply it at bootstrap

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cea07cc5548333a4aaa7a2c60d4be4