### PR TITLE
Make reset password link more prominent

### DIFF
--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -112,9 +112,10 @@ function LoginPage() {
             <div className="text-right">
               <Link
                 to="/reset-password"
-                className={`${bodySmallStrongTextClasses} text-emerald-700 transition hover:text-emerald-600`}
+                className={`${bodySmallStrongTextClasses} inline-flex items-center justify-end gap-1 text-emerald-700 underline decoration-emerald-300 decoration-2 underline-offset-4 transition hover:text-emerald-600`}
               >
-                Forgot your password?
+                <span aria-hidden="true">Forgot your password?</span>
+                <span className="sr-only">Forgot your password? Reset it.</span>
               </Link>
             </div>
             {error && (


### PR DESCRIPTION
## Summary
- underline and align the reset password link on the login page so it is easier to spot
- add screen-reader only helper text that announces the reset action

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cf4229973c8333ae2b757a160e0d9b