### PR TITLE
Use a single forgot password route

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,7 +5,7 @@ import GlobalErrorBoundary from "./components/GlobalErrorBoundary";
 import LandingPage from "./pages/LandingPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
-import ResetPasswordPage from "./pages/ResetPasswordPage";
+import ForgotPasswordPage from "./pages/ForgotPasswordPage";
 import JournalerDashboard from "./pages/JournalerDashboard";
 import MentorDashboard from "./pages/MentorDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
@@ -50,6 +50,20 @@ function ProtectedRoute({ roles, children }) {
   return children;
 }
 
+function PublicOnlyRoute({ children, redirectTo = "/dashboard" }) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <LoadingState label="Lighting the Aleya path" />;
+  }
+
+  if (user) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return children;
+}
+
 function AppRoutes() {
   const { user } = useAuth();
 
@@ -63,23 +77,27 @@ function AppRoutes() {
           />
           <Route
             path="/login"
-            element={user ? <Navigate to="/dashboard" replace /> : <LoginPage />}
+            element={
+              <PublicOnlyRoute>
+                <LoginPage />
+              </PublicOnlyRoute>
+            }
           />
           <Route
             path="/forgot-password"
             element={
-              user ? <Navigate to="/dashboard" replace /> : <ResetPasswordPage />
-            }
-          />
-          <Route
-            path="/reset-password"
-            element={
-              user ? <Navigate to="/dashboard" replace /> : <ResetPasswordPage />
+              <PublicOnlyRoute>
+                <ForgotPasswordPage />
+              </PublicOnlyRoute>
             }
           />
           <Route
             path="/register"
-            element={user ? <Navigate to="/dashboard" replace /> : <RegisterPage />}
+            element={
+              <PublicOnlyRoute>
+                <RegisterPage />
+              </PublicOnlyRoute>
+            }
           />
           <Route path="/verify-email" element={<VerifyEmailPage />} />
           <Route

--- a/frontend/src/pages/ForgotPasswordPage.js
+++ b/frontend/src/pages/ForgotPasswordPage.js
@@ -14,7 +14,7 @@ import {
   secondaryButtonClasses,
 } from "../styles/ui";
 
-function ResetPasswordPage() {
+function ForgotPasswordPage() {
   const [searchParams] = useSearchParams();
   const rawToken = searchParams.get("token");
   const token = rawToken ? rawToken.trim() : "";
@@ -273,7 +273,7 @@ function ResetPasswordPage() {
               <p className={`mt-4 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}>
                 Need a fresh link?{" "}
                 <Link
-                  to="/reset-password"
+                  to="/forgot-password"
                   className="font-semibold text-emerald-700 transition hover:text-emerald-600"
                 >
                   Request another reset email
@@ -311,4 +311,4 @@ function ResetPasswordPage() {
   );
 }
 
-export default ResetPasswordPage;
+export default ForgotPasswordPage;

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -111,11 +111,10 @@ function LoginPage() {
             </label>
             <div className="text-right">
               <Link
-                to="/reset-password"
-                className={`${bodySmallStrongTextClasses} inline-flex items-center justify-end gap-1 text-emerald-700 underline decoration-emerald-300 decoration-2 underline-offset-4 transition hover:text-emerald-600`}
+                to="/forgot-password"
+                className={`${bodySmallStrongTextClasses} text-emerald-700 underline decoration-emerald-300 decoration-2 underline-offset-4 transition hover:text-emerald-600`}
               >
-                <span aria-hidden="true">Forgot your password?</span>
-                <span className="sr-only">Forgot your password? Reset it.</span>
+                Forgot password?
               </Link>
             </div>
             {error && (


### PR DESCRIPTION
## Summary
- remove the duplicate `/reset-password` route so password recovery lives solely at `/forgot-password`
- rename the password recovery screen to `ForgotPasswordPage` and update all internal links to the canonical route

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cf495b86d88333ba7327a4dbf9091c