### PR TITLE
Normalize frontend components to shared CSS tokens

### DIFF
--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -4,64 +4,64 @@
 - **Location:** `frontend/src/components/Layout.js`
 - **Props:** `children`
 - **Purpose:** Wraps authenticated + marketing shells with sticky header, role-based navigation, PanicButton, and auth controls.
-- **Dependencies:** `AuthContext` for user/session info, `react-router-dom` for links, `PanicButton` for SOS dialog, Tailwind tokens from `styles/ui`.
+- **Dependencies:** `AuthContext` for user/session info, `react-router-dom` for links, `PanicButton` for SOS dialog, and layout tokens (`app-shell`, `primary-nav*`, `mobile-menu*`, `auth-controls*`, `button-pad-*`, `button-responsive`, `icon-sm`) from `styles/ui`.
 
 ## GlobalErrorBoundary
 - **Location:** `frontend/src/components/GlobalErrorBoundary.js`
 - **Props:** `children`
 - **Purpose:** Captures render/runtime errors, listens for promise rejections, and renders a luminous fallback with reset + reload options.
-- **Dependencies:** Browser `window` events, `useEffect`, `useState` for boundary lifecycle.
+- **Dependencies:** Browser `window` events, `useEffect`, `useState` for boundary lifecycle, and `error-*` + `button-pad-md` tokens for the fallback surface.
 
 ## JournalEntryForm
 - **Location:** `frontend/src/components/JournalEntryForm.js`
-- **Props:** `forms`, `selectedForm`, `onSelectForm`, `onSubmit`, `submitting`, `statusMessage`, `statusVariant`, `onStatusClose`, `formResetKey`
-- **Purpose:** Renders mentor-authored prompts, collects responses, mood, share level, and summary for new journal entries.
-- **Dependencies:** `TagInput` for gratitude/expertise tags, UI tokens for inputs, `getShareChipClasses` for share level hints.
+- **Props:** `form`, `onSubmit`, `submitting`, `defaultSharing`, `initialSharing`, `initialValues`, `statusMessage`, `statusVariant`, `submitLabel`, `onCancel`
+- **Purpose:** Renders mentor-authored prompts, collects responses, and persists the sharing level for new journal entries.
+- **Dependencies:** Form tokens (`form-*`), input tokens, and button helpers (`button-responsive`, `button-pad-*`) from `styles/ui`.
 
 ## MetricCard
 - **Location:** `frontend/src/components/MetricCard.js`
-- **Props:** `title`, `value`, `caption`, `trend`, `tone`
-- **Purpose:** Displays journaler and mentor dashboard metrics with optional sparkline trend chips.
-- **Dependencies:** UI tokens (`card-container`, typography) and mood helpers for color coding.
+- **Props:** `title`, `value`, `description`, `children`
+- **Purpose:** Displays dashboard metrics with optional supporting copy or custom child content.
+- **Dependencies:** Metric card token exports (`metric-card*`) from `styles/ui` keep typography and padding aligned.
 
 ## MoodTrendChart
 - **Location:** `frontend/src/components/MoodTrendChart.js`
-- **Props:** `data`, `title`, `emptyLabel`
-- **Purpose:** Renders a responsive SVG line chart of mood or wellbeing scores across selectable timeframes.
-- **Dependencies:** Pure React/SVG; consumes `getMoodBadgeClasses` for tooltips.
+- **Props:** `data`
+- **Purpose:** Renders a responsive SVG line chart of recent mood or wellbeing scores with a legend of the latest entries.
+- **Dependencies:** `date-fns` for formatting and `styles/ui` mood chart tokens (including `mood-chart__legend-copy`) for layout; falls back to `emptyStateClasses` when no data exists.
 
 ## MentorRequestList
 - **Location:** `frontend/src/components/MentorRequestList.js`
-- **Props:** `requests`, `onAccept`, `onConfirm`, `onDecline`, `loading`
-- **Purpose:** Lists mentorship requests for both roles, exposing action buttons and status chips.
-- **Dependencies:** UI button tokens, `getStatusToneClasses` for state coloring.
+- **Props:** `requests`, `role`, `onAccept`, `onConfirm`, `onDecline`, `onEnd`
+- **Purpose:** Lists mentorship requests for mentors and journalers, surfacing action buttons and status copy per state.
+- **Dependencies:** Compact button tokens (`btn-primary-compact`, `btn-secondary-compact`), request list classes (`request-list`, `request-card*`), and status tone helpers (`request-status--*`).
 
 ## MentorProfileDialog
 - **Location:** `frontend/src/components/MentorProfileDialog.js`
-- **Props:** `mentor`, `onClose`, `onLink`, `linking`
-- **Purpose:** Modal for admins to review mentor bios/expertise and link journalers.
-- **Dependencies:** Shared modal layout pattern (`fixed inset-0`, scrollable panel), UI buttons, `TagInput` for expertise chips.
+- **Props:** `mentor`, `onClose`, `onRequest`, `canRequest`
+- **Purpose:** Journaler-facing modal that reveals mentor expertise, bio, and availability with an optional request CTA.
+- **Dependencies:** Shared dialog tokens (`dialog-*`, `button-pad-*`) plus chip tokens for consistent styling.
 
 ## PanicButton
 - **Location:** `frontend/src/components/PanicButton.js`
 - **Props:** None
 - **Purpose:** Journaler-only SOS launcher that fetches linked mentors, sends panic alerts, and surfaces success/error copy.
-- **Dependencies:** `AuthContext` for token + role, `/mentors/support-network` + `/mentors/panic-alerts` API calls via `apiClient`.
+- **Dependencies:** `AuthContext` for token + role, `/mentors/support-network` + `/mentors/panic-alerts` API calls via `apiClient`, and dialog tokens shared with the mentor profile modal.
 
 ## SectionCard
 - **Location:** `frontend/src/components/SectionCard.js`
 - **Props:** `title`, `subtitle`, `actions`, `children`, `sectionRef`, `titleRef`, `titleProps`
 - **Purpose:** Section wrapper for dashboards, supporting focus/scroll targeting to improve accessibility.
-- **Dependencies:** UI card + typography tokens; forwards refs for guided flows.
+- **Dependencies:** UI card + typography tokens and section layout helpers (`section-card__*`); forwards refs for guided flows.
 
 ## TagInput
 - **Location:** `frontend/src/components/TagInput.js`
-- **Props:** `label`, `name`, `value`, `onChange`, `suggestions`, `placeholder`, `disabled`
-- **Purpose:** Tokenized multi-select input used for mentor expertise and gratitude tags with suggestion dropdown.
-- **Dependencies:** `useExpertiseSuggestions` for mentor flows, UI chip tokens, keyboard navigation handlers.
+- **Props:** `value`, `onChange`, `placeholder`, `suggestions`, `allowCustom`
+- **Purpose:** Tokenised multi-select input used for expertise chips with auto-complete suggestions and custom entry support.
+- **Dependencies:** `parseExpertise` for normalising values and tag input token exports (`tag-input*`) for consistent styling.
 
 ## LoadingState
 - **Location:** `frontend/src/components/LoadingState.js`
-- **Props:** `label`
-- **Purpose:** Displays animated shimmer and poetic loading text during async fetches and route guards.
-- **Dependencies:** UI typography tokens.
+- **Props:** `label`, `compact`
+- **Purpose:** Displays poetic loading copy either full-height or inline while async data resolves.
+- **Dependencies:** Loading state tokens (`loading-state*`) from `styles/ui`.

--- a/docs/frontend/theme.md
+++ b/docs/frontend/theme.md
@@ -14,10 +14,13 @@
 - `form-label` keeps input guidance in Emerald 900/80 for accessibility.
 
 ## Component Tokens
-- Buttons: `btn-primary`, `btn-secondary`, `btn-subtle`, `btn-danger`, and circular `icon-button` share rounded 2xl shapes and motion hover states.
-- Forms: `form-input`, `form-input-compact`, `form-select`, `form-select-compact`, `form-textarea`, `form-checkbox` apply frosted backgrounds and emerald focus rings.
-- Feedback + layout: `empty-state`, `card-container`, `table-header`, `table-row`, `chip-base`, `badge-base`, `section-title`, `section-subtitle` keep admin tables, cards, and chips consistent.
-- Status helpers: `getMoodBadgeClasses`, `getShareChipClasses`, and `getStatusToneClasses` map moods, share levels, and mentor request states to Tailwind utility blends.
+- Buttons: `btn-primary`, `btn-secondary`, `btn-subtle`, `btn-danger`, and circular `icon-button` share rounded 2xl shapes and motion hover states; compact variants (`btn-primary-compact`, `btn-secondary-compact`) plus padding helpers (`button-pad-*`), layout utilities (`button-block`, `button-responsive`), and `icon-sm` keep actions balanced across contexts.
+- Layout & navigation: `app-shell`, `app-header*`, `primary-nav*`, `mobile-menu*`, `auth-controls*`, and spacing helpers (`stack-*`, `cluster-*`) orchestrate the shell, navigation, and responsive spacing.
+- Forms: `form-input`, `form-input-compact`, `form-select`, `form-select-compact`, `form-textarea`, `form-checkbox`, and support classes (`form-*` helpers, status banners, `form-actions`) apply frosted backgrounds, emerald focus rings, and consistent feedback styling.
+- Feedback + layout: `empty-state`, `card-container`, `table-header`, `table-row`, `chip-base`, `badge-base`, `section-title`, `section-subtitle`, `section-card__*`, `error-*`, and `dialog-*` keep admin tables, cards, dialogs, and fallbacks consistent.
+- Dashboard metrics and charts: `metric-card*`, `mood-chart*` (including `mood-chart__legend-copy`), and `loading-state*` unify stats, sparklines, and loading affordances across dashboards.
+- Interactive lists & inputs: `request-list`, `request-card*`, `request-status--*`, and `tag-input*` align mentorship requests and chip-style inputs with the shared emerald styling.
+- Status helpers: `getMoodBadgeClasses`, `getShareChipClasses`, and `getStatusToneClasses` now return CSS token blends (`badge-mood-*`, `chip-share-*`, `request-status--*`) so components never reach for raw Tailwind utilities.
 
 ## Motion & Depth
 - Buttons ease upward with subtle translate-y hover states and focus outlines.

--- a/frontend/src/components/GlobalErrorBoundary.js
+++ b/frontend/src/components/GlobalErrorBoundary.js
@@ -1,8 +1,15 @@
 import { Component } from "react";
 import {
-  bodySmallMutedTextClasses,
-  bodyTextClasses,
-  largeHeadingClasses,
+  buttonPadMdClasses,
+  errorActionsClasses,
+  errorCopyClasses,
+  errorDetailsClasses,
+  errorDetailsPanelClasses,
+  errorDetailsToggleClasses,
+  errorFooterClasses,
+  errorHeadingClasses,
+  errorPanelClasses,
+  errorShellClasses,
   primaryButtonClasses,
   secondaryButtonClasses,
 } from "../styles/ui";
@@ -162,48 +169,48 @@ class GlobalErrorBoundary extends Component {
     const detailContent = error?.stack || errorInfo || "";
 
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-emerald-100 px-6 py-16">
-        <div className="w-full max-w-xl rounded-3xl border border-emerald-200/70 bg-white/80 p-10 text-center shadow-lg shadow-emerald-200/50 backdrop-blur">
-          <h1 className={`${largeHeadingClasses} text-emerald-900`}>We wandered into a thicket.</h1>
-          <p className={`${bodyTextClasses} mt-4 text-emerald-900/80`}>
+      <div className={errorShellClasses}>
+        <div className={errorPanelClasses}>
+          <h1 className={errorHeadingClasses}>We wandered into a thicket.</h1>
+          <p className={errorCopyClasses}>
             Something unexpected rustled the canopy. We have safely paused the experience
             so you can choose how to continue.
           </p>
-          <div className="mt-8 flex flex-wrap justify-center gap-3">
+          <div className={errorActionsClasses}>
             <button
               type="button"
-              className={`${primaryButtonClasses} px-6 py-2.5`}
+              className={`${primaryButtonClasses} ${buttonPadMdClasses}`}
               onClick={this.handleReset}
             >
               Try again
             </button>
             <button
               type="button"
-              className={`${secondaryButtonClasses} px-6 py-2.5`}
+              className={`${secondaryButtonClasses} ${buttonPadMdClasses}`}
               onClick={this.handleReload}
             >
               Return to the clearing
             </button>
           </div>
           {detailContent ? (
-            <div className="mt-8 text-left">
+            <div className={errorDetailsClasses}>
               <button
                 type="button"
-                className={`${bodyTextClasses} underline-offset-4 transition hover:underline`}
+                className={errorDetailsToggleClasses}
                 onClick={this.toggleDetails}
               >
                 {showDetails ? "Hide technical whispers" : "Show technical whispers"}
               </button>
               {showDetails ? (
                 <pre
-                  className={`${bodySmallMutedTextClasses} mt-4 max-h-48 overflow-auto rounded-2xl bg-emerald-50/80 p-4 text-sm leading-relaxed`}
+                  className={errorDetailsPanelClasses}
                 >
                   {detailContent}
                 </pre>
               ) : null}
             </div>
           ) : null}
-          <p className={`${bodySmallMutedTextClasses} mt-8`}>
+          <p className={errorFooterClasses}>
             If the path keeps closing, please share these details with the Aleya team so we can guide the light back home.
           </p>
         </div>

--- a/frontend/src/components/JournalEntryForm.js
+++ b/frontend/src/components/JournalEntryForm.js
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  bodySmallMutedTextClasses,
-  bodySmallStrongTextClasses,
   emptyStateClasses,
   formLabelClasses,
   infoTextClasses,
@@ -11,6 +9,17 @@ import {
   subtleButtonClasses,
   selectClasses,
   textareaClasses,
+  formStackClasses,
+  formSectionClasses,
+  formHelperClasses,
+  formRequiredClasses,
+  formStatusClasses,
+  formStatusErrorClasses,
+  formStatusInfoClasses,
+  formStatusSuccessClasses,
+  formActionsClasses,
+  buttonResponsiveClasses,
+  stackSmClasses,
 } from "../styles/ui";
 
 const DEFAULT_SHARING = "private";
@@ -99,8 +108,8 @@ function JournalEntryForm({
   };
 
   return (
-    <form className="space-y-5" onSubmit={handleSubmit}>
-      <div>
+    <form className={formStackClasses} onSubmit={handleSubmit}>
+      <div className={stackSmClasses}>
         <h3 className={`${mediumHeadingClasses} text-emerald-900`}>
           {form.title}
         </h3>
@@ -109,24 +118,24 @@ function JournalEntryForm({
         )}
       </div>
       {form.fields.map((field) => (
-        <div className="space-y-2" key={field.id ?? field.label}>
-          <label className={`block ${formLabelClasses}`}>
+        <div className={formSectionClasses} key={field.id ?? field.label}>
+          <label className={formLabelClasses}>
             <span>
               {field.label}
-              {field.required && <span className="ml-1 text-rose-500">*</span>}
+              {field.required && <span className={formRequiredClasses}>*</span>}
             </span>
             {renderField(field, values[field.id ?? field.label] || "", (value) =>
               handleChange(field, value)
             )}
           </label>
           {field.helperText && (
-            <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
+            <p className={formHelperClasses}>
               {field.helperText}
             </p>
           )}
         </div>
       ))}
-      <div className="space-y-2">
+      <div className={formSectionClasses}>
         <label htmlFor="sharing" className={`block ${formLabelClasses}`}>
           Sharing preference
         </label>
@@ -142,32 +151,32 @@ function JournalEntryForm({
             </option>
           ))}
         </select>
-        <p className={`${bodySmallMutedTextClasses} text-emerald-900/60`}>
+        <p className={formHelperClasses}>
           Decide how much of this entry your mentors can see.
         </p>
       </div>
       {error && (
         <p
-          className={`rounded-2xl border border-rose-100 bg-rose-50/80 px-4 py-3 ${bodySmallStrongTextClasses} text-rose-600`}
+          className={`${formStatusClasses} ${formStatusErrorClasses}`}
         >
           {error}
         </p>
       )}
       {statusMessage && (
         <p
-          className={`rounded-2xl px-4 py-3 ${bodySmallStrongTextClasses} ${
+          className={`${formStatusClasses} ${
             statusVariant === "success"
-              ? "border border-emerald-100 bg-emerald-50/80 text-emerald-700"
-              : "border border-emerald-100 bg-white/80 text-emerald-900/70"
+              ? formStatusSuccessClasses
+              : formStatusInfoClasses
           }`}
         >
           {statusMessage}
         </p>
       )}
-      <div className="flex flex-col gap-3 sm:flex-row">
+      <div className={formActionsClasses}>
         <button
           type="submit"
-          className={`${primaryButtonClasses} w-full sm:w-auto`}
+          className={`${primaryButtonClasses} ${buttonResponsiveClasses}`}
           disabled={!canSubmit || submitting}
         >
           {submitting ? "Saving..." : submitLabel}
@@ -175,7 +184,7 @@ function JournalEntryForm({
         {onCancel && (
           <button
             type="button"
-            className={`${subtleButtonClasses} w-full sm:w-auto`}
+            className={`${subtleButtonClasses} ${buttonResponsiveClasses}`}
             onClick={onCancel}
             disabled={submitting}
           >

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -3,14 +3,43 @@ import { NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import PanicButton from "./PanicButton";
 import {
-  bodySmallMutedTextClasses,
-  bodySmallStrongTextClasses,
-  captionTextClasses,
-  largeHeadingClasses,
-  primaryButtonClasses,
-  secondaryButtonClasses,
-  subtleButtonClasses,
+  appBrandClasses,
+  appFooterClasses,
+  appFooterContentClasses,
+  appHeaderClasses,
+  appHeaderInnerClasses,
+  appHeaderRowClasses,
+  appMainClasses,
+  appShellClasses,
+  authControlsClasses,
+  authControlsNameClasses,
+  authControlsRoleClasses,
+  authControlsTextClasses,
+  authControlsTextVerticalClasses,
+  authControlsVerticalClasses,
+  buttonBlockClasses,
+  buttonPadSmClasses,
+  buttonPadXsClasses,
+  headerActionsClasses,
   iconButtonClasses,
+  iconSmallClasses,
+  mobileActionsClasses,
+  mobileActionsToggleActiveClasses,
+  mobileMenuClasses,
+  mobileMenuDividerClasses,
+  mobileMenuPanelClasses,
+  mobileNavClasses,
+  mobileNavLinkActiveClasses,
+  mobileNavLinkClasses,
+  mobileNavLinkInactiveClasses,
+  primaryButtonClasses,
+  primaryNavClasses,
+  primaryNavLinkActiveClasses,
+  primaryNavLinkClasses,
+  primaryNavLinkInactiveClasses,
+  secondaryButtonClasses,
+  srOnlyClasses,
+  subtleButtonClasses,
 } from "../styles/ui";
 
 const roleNavigation = {
@@ -60,13 +89,16 @@ function Layout({ children }) {
     if (user) {
       const containerClasses =
         orientation === "vertical"
-          ? "flex flex-col gap-3"
-          : "flex items-center gap-4";
-      const textAlignment = orientation === "vertical" ? "text-left" : "text-right";
+          ? authControlsVerticalClasses
+          : authControlsClasses;
+      const textClasses =
+        orientation === "vertical"
+          ? authControlsTextVerticalClasses
+          : authControlsTextClasses;
       const buttonClasses =
         orientation === "vertical"
-          ? `${secondaryButtonClasses} w-full px-5 py-2.5 text-sm`
-          : `${secondaryButtonClasses} px-5 py-2.5 text-sm`;
+          ? `${secondaryButtonClasses} ${buttonPadSmClasses} ${buttonBlockClasses}`
+          : `${secondaryButtonClasses} ${buttonPadSmClasses}`;
 
       const handleLogoutClick = () => {
         handleLogout();
@@ -77,11 +109,9 @@ function Layout({ children }) {
 
       return (
         <div className={containerClasses}>
-          <div className={textAlignment}>
-            <span className={`block ${bodySmallStrongTextClasses} text-emerald-900`}>
-              {user.name}
-            </span>
-            <span className={`${captionTextClasses} text-emerald-900/60`}>{user.role}</span>
+          <div className={textClasses}>
+            <span className={authControlsNameClasses}>{user.name}</span>
+            <span className={authControlsRoleClasses}>{user.role}</span>
           </div>
           <button type="button" className={buttonClasses} onClick={handleLogoutClick}>
             Log out
@@ -92,18 +122,18 @@ function Layout({ children }) {
 
     const containerClasses =
       orientation === "vertical"
-        ? "flex flex-col gap-3"
-        : "flex flex-wrap items-center gap-3";
+        ? authControlsVerticalClasses
+        : authControlsClasses;
 
     const signInClasses =
       orientation === "vertical"
-        ? `${subtleButtonClasses} w-full justify-center px-4 py-2`
-        : `${subtleButtonClasses} px-4 py-2`;
+        ? `${subtleButtonClasses} ${buttonPadXsClasses} ${buttonBlockClasses}`
+        : `${subtleButtonClasses} ${buttonPadXsClasses}`;
 
     const joinClasses =
       orientation === "vertical"
-        ? `${primaryButtonClasses} w-full justify-center px-5 py-2.5 text-sm`
-        : `${primaryButtonClasses} px-5 py-2.5 text-sm`;
+        ? `${primaryButtonClasses} ${buttonPadSmClasses} ${buttonBlockClasses}`
+        : `${primaryButtonClasses} ${buttonPadSmClasses}`;
 
     const handleNavigate = () => {
       if (orientation === "vertical") {
@@ -124,29 +154,29 @@ function Layout({ children }) {
   };
 
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-emerald-50 via-white to-emerald-100 text-emerald-950">
-      <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/85 backdrop-blur">
-        <div className="relative mx-auto w-full max-w-6xl px-6 py-3">
-          <div className="flex w-full items-center gap-3">
+    <div className={appShellClasses}>
+      <header className={appHeaderClasses}>
+        <div className={appHeaderInnerClasses}>
+          <div className={appHeaderRowClasses}>
             <button
               type="button"
-              className={`rounded-full border border-transparent bg-transparent leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${largeHeadingClasses}`}
+              className={appBrandClasses}
               onClick={() => navigate(user ? "/dashboard" : "/")}
             >
               Aleya
             </button>
             <nav
-              className={`hidden flex-1 items-center justify-center gap-1 md:flex ${bodySmallStrongTextClasses} text-emerald-900/70`}
+              className={primaryNavClasses}
             >
               {links.map((link) => (
                 <NavLink
                   key={link.to}
                   to={link.to}
                   className={({ isActive }) =>
-                    `rounded-full px-4 py-2 transition ${
+                    `${primaryNavLinkClasses} ${
                       isActive
-                        ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
-                        : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
+                        ? primaryNavLinkActiveClasses
+                        : primaryNavLinkInactiveClasses
                     }`
                   }
                 >
@@ -154,22 +184,22 @@ function Layout({ children }) {
                 </NavLink>
               ))}
             </nav>
-            <div className="hidden items-center gap-3 md:flex">
+            <div className={headerActionsClasses}>
               <PanicButton />
               <AuthControls />
             </div>
-            <div className="ml-auto flex items-center gap-3 md:hidden">
+            <div className={mobileActionsClasses}>
               <PanicButton />
               <button
                 type="button"
                 className={`${iconButtonClasses} ${
-                  isMobileMenuOpen ? "bg-emerald-600 text-white hover:text-white" : ""
-                }`}
+                  isMobileMenuOpen ? mobileActionsToggleActiveClasses : ""
+                }`.trim()}
                 onClick={toggleMobileMenu}
                 aria-expanded={isMobileMenuOpen}
                 aria-controls="mobile-navigation"
               >
-                <span className="sr-only">
+                <span className={srOnlyClasses}>
                   {isMobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
                 </span>
                 {isMobileMenuOpen ? (
@@ -179,7 +209,7 @@ function Layout({ children }) {
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="1.5"
-                    className="h-5 w-5"
+                    className={iconSmallClasses}
                     aria-hidden="true"
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -191,7 +221,7 @@ function Layout({ children }) {
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="1.5"
-                    className="h-5 w-5"
+                    className={iconSmallClasses}
                     aria-hidden="true"
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -201,21 +231,21 @@ function Layout({ children }) {
             </div>
           </div>
           {isMobileMenuOpen && (
-            <div className="absolute left-0 right-0 top-full mt-3 md:hidden" id="mobile-navigation">
-              <div className="rounded-3xl border border-emerald-100 bg-white/95 p-4 shadow-xl shadow-emerald-900/10 backdrop-blur">
+            <div className={mobileMenuClasses} id="mobile-navigation">
+              <div className={mobileMenuPanelClasses}>
                 {links.length > 0 && (
                   <nav
-                    className={`flex flex-col gap-2 ${bodySmallStrongTextClasses} text-emerald-900/80`}
+                    className={mobileNavClasses}
                   >
                     {links.map((link) => (
                       <NavLink
                         key={link.to}
                         to={link.to}
                         className={({ isActive }) =>
-                          `rounded-full px-4 py-2 transition ${
+                          `${mobileNavLinkClasses} ${
                             isActive
-                              ? "bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10"
-                              : "text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700"
+                              ? mobileNavLinkActiveClasses
+                              : mobileNavLinkInactiveClasses
                           }`
                         }
                         onClick={closeMobileMenu}
@@ -225,7 +255,7 @@ function Layout({ children }) {
                     ))}
                   </nav>
                 )}
-                <div className="mt-4 border-t border-emerald-100/70 pt-4">
+                <div className={mobileMenuDividerClasses}>
                   <AuthControls orientation="vertical" onNavigate={closeMobileMenu} />
                 </div>
               </div>
@@ -233,13 +263,11 @@ function Layout({ children }) {
           )}
         </div>
       </header>
-      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-12">
+      <main className={appMainClasses}>
         {children}
       </main>
-      <footer className="border-t border-emerald-100 bg-white/70">
-        <div
-          className={`mx-auto w-full max-w-6xl px-6 py-6 text-center ${bodySmallMutedTextClasses} text-emerald-900/70`}
-        >
+      <footer className={appFooterClasses}>
+        <div className={appFooterContentClasses}>
           Tend your breath, follow the light, and share the harvest of your days.
         </div>
       </footer>

--- a/frontend/src/components/LoadingState.js
+++ b/frontend/src/components/LoadingState.js
@@ -1,7 +1,9 @@
+import { loadingStateClasses, loadingStateFullClasses } from "../styles/ui";
+
 function LoadingState({ label = "Gathering the morning light", compact = false }) {
   const containerClasses = compact
-    ? "flex items-center justify-center text-sm font-medium text-emerald-900/70"
-    : "flex min-h-[40vh] items-center justify-center text-sm font-medium text-emerald-900/70";
+    ? loadingStateClasses
+    : `${loadingStateClasses} ${loadingStateFullClasses}`;
 
   return <div className={containerClasses}>{label}…</div>;
 }

--- a/frontend/src/components/MentorProfileDialog.js
+++ b/frontend/src/components/MentorProfileDialog.js
@@ -1,10 +1,22 @@
 import {
-  bodyTextClasses,
   bodySmallMutedTextClasses,
+  bodyTextClasses,
   chipBaseClasses,
-  mediumHeadingClasses,
+  dialogActionsClasses,
+  dialogBackdropClasses,
+  dialogBodyClasses,
+  dialogCloseClasses,
+  dialogHeaderClasses,
+  dialogHeadingGroupClasses,
+  dialogPanelClasses,
+  dialogSectionClasses,
+  dialogSectionTitleClasses,
+  dialogTitleClasses,
+  mentorDialogChipsClasses,
   primaryButtonClasses,
   secondaryButtonClasses,
+  buttonPadSmClasses,
+  textPreLineClasses,
 } from "../styles/ui";
 import { parseExpertise } from "../utils/expertise";
 
@@ -21,26 +33,23 @@ function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-emerald-950/40 px-4 py-10"
+      className={dialogBackdropClasses}
       role="dialog"
       aria-modal="true"
       aria-labelledby="mentor-profile-heading"
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl sm:p-8"
+        className={dialogPanelClasses}
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
-            <h2
-              id="mentor-profile-heading"
-              className={`${mediumHeadingClasses} text-emerald-900`}
-            >
+        <div className={dialogHeaderClasses}>
+          <div className={dialogHeadingGroupClasses}>
+            <h2 id="mentor-profile-heading" className={dialogTitleClasses}>
               {mentor.name}
             </h2>
             {expertiseTags.length > 0 && (
-              <div className="flex flex-wrap gap-2">
+              <div className={mentorDialogChipsClasses}>
                 {expertiseTags.map((tag) => (
                   <span key={tag} className={chipBaseClasses}>
                     {tag}
@@ -55,16 +64,16 @@ function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
           <button
             type="button"
             onClick={onClose}
-            className={`${secondaryButtonClasses} px-4 py-2 text-sm`}
+            className={`${secondaryButtonClasses} ${dialogCloseClasses}`}
           >
             Close
           </button>
         </div>
 
-        <div className="mt-6 space-y-4">
+        <div className={dialogBodyClasses}>
           {mentor.availability && (
-            <div>
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-800/70">
+            <div className={dialogSectionClasses}>
+              <h3 className={dialogSectionTitleClasses}>
                 Availability
               </h3>
               <p className={bodyTextClasses}>{mentor.availability}</p>
@@ -72,11 +81,11 @@ function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
           )}
 
           {mentor.bio && (
-            <div>
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-emerald-800/70">
+            <div className={dialogSectionClasses}>
+              <h3 className={dialogSectionTitleClasses}>
                 About
               </h3>
-              <p className={`${bodyTextClasses} whitespace-pre-line`}>{mentor.bio}</p>
+              <p className={`${bodyTextClasses} ${textPreLineClasses}`}>{mentor.bio}</p>
             </div>
           )}
 
@@ -88,10 +97,10 @@ function MentorProfileDialog({ mentor, onClose, onRequest, canRequest }) {
         </div>
 
         {canRequest && (
-          <div className="mt-8 flex flex-wrap justify-end gap-3">
+          <div className={dialogActionsClasses}>
             <button
               type="button"
-              className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
+              className={`${primaryButtonClasses} ${buttonPadSmClasses}`}
               onClick={handleRequest}
             >
               Request mentorship

--- a/frontend/src/components/MentorRequestList.js
+++ b/frontend/src/components/MentorRequestList.js
@@ -1,8 +1,15 @@
 import {
   emptyStateClasses,
   getStatusToneClasses,
-  primaryButtonClasses,
-  secondaryButtonClasses,
+  primaryButtonCompactClasses,
+  requestCardActionsClasses,
+  requestCardBodyClasses,
+  requestCardClasses,
+  requestCardMessageClasses,
+  requestCardStatusClasses,
+  requestCardTitleClasses,
+  requestListClasses,
+  secondaryButtonCompactClasses,
 } from "../styles/ui";
 
 function MentorRequestList({
@@ -20,38 +27,44 @@ function MentorRequestList({
   }
 
   return (
-    <ul className="grid gap-4">
+    <ul className={requestListClasses}>
       {requests.map((request) => (
         <li
           key={request.id}
-          className="flex flex-wrap items-start justify-between gap-4 rounded-2xl border border-emerald-100 bg-white/70 p-5"
+          className={requestCardClasses}
         >
-          <div className="space-y-1 text-emerald-900">
-            <h4 className="text-base font-semibold">
+          <div className={requestCardBodyClasses}>
+            <h4 className={requestCardTitleClasses}>
               {role === "mentor"
                 ? request.journaler.name
                 : request.mentor.name}
             </h4>
-            <p className={`${getStatusToneClasses(request.status)} text-sm`}>
+            <p
+              className={`${getStatusToneClasses(
+                request.status
+              )} ${requestCardStatusClasses}`}
+            >
               {formatStatus(request.status)}
             </p>
             {request.message && (
-              <p className="text-sm text-emerald-900/70">“{request.message}”</p>
+              <p className={requestCardMessageClasses}>
+                “{request.message}”
+              </p>
             )}
           </div>
-          <div className="flex flex-wrap items-center gap-3">
+          <div className={requestCardActionsClasses}>
             {role === "mentor" && request.status === "pending" && (
               <>
                 <button
                   type="button"
-                  className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
+                  className={primaryButtonCompactClasses}
                   onClick={() => onAccept(request)}
                 >
                   Accept
                 </button>
                 <button
                   type="button"
-                  className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                  className={secondaryButtonCompactClasses}
                   onClick={() => onDecline(request)}
                 >
                   Decline
@@ -62,14 +75,14 @@ function MentorRequestList({
               <>
                 <button
                   type="button"
-                  className={`${primaryButtonClasses} px-5 py-2.5 text-sm`}
+                  className={primaryButtonCompactClasses}
                   onClick={() => onConfirm(request)}
                 >
                   Confirm link
                 </button>
                 <button
                   type="button"
-                  className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                  className={secondaryButtonCompactClasses}
                   onClick={() => onDecline(request)}
                 >
                   Decline
@@ -81,7 +94,7 @@ function MentorRequestList({
               typeof onEnd === "function" && (
                 <button
                   type="button"
-                  className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                  className={secondaryButtonCompactClasses}
                   onClick={() => onEnd(request)}
                 >
                   End mentorship

--- a/frontend/src/components/MetricCard.js
+++ b/frontend/src/components/MetricCard.js
@@ -1,14 +1,20 @@
+import {
+  metricCardClasses,
+  metricCardDescriptionClasses,
+  metricCardDetailsClasses,
+  metricCardLabelClasses,
+  metricCardValueClasses,
+} from "../styles/ui";
+
 function MetricCard({ title, value, description, children }) {
   return (
-    <div className="rounded-2xl border border-emerald-100 bg-white/70 p-5 shadow-inner shadow-emerald-900/5">
-      <span className="text-xs font-semibold uppercase tracking-wide text-emerald-900/60">
-        {title}
-      </span>
-      <div className="mt-3 text-3xl font-bold text-emerald-900">{value}</div>
+    <div className={metricCardClasses}>
+      <span className={metricCardLabelClasses}>{title}</span>
+      <div className={metricCardValueClasses}>{value}</div>
       {description && (
-        <p className="mt-2 text-sm text-emerald-900/70">{description}</p>
+        <p className={metricCardDescriptionClasses}>{description}</p>
       )}
-      {children && <div className="mt-4 text-sm text-emerald-900/70">{children}</div>}
+      {children && <div className={metricCardDetailsClasses}>{children}</div>}
     </div>
   );
 }

--- a/frontend/src/components/MoodTrendChart.js
+++ b/frontend/src/components/MoodTrendChart.js
@@ -1,5 +1,15 @@
 import { format, parseISO } from "date-fns";
-import { emptyStateClasses } from "../styles/ui";
+import {
+  emptyStateClasses,
+  moodChartContainerClasses,
+  moodChartLegendClasses,
+  moodChartLegendCopyClasses,
+  moodChartLegendDateClasses,
+  moodChartLegendDotClasses,
+  moodChartLegendItemClasses,
+  moodChartLegendLabelClasses,
+  moodChartVisualClasses,
+} from "../styles/ui";
 
 const MOOD_COLORS = {
   happy: "#2f855a",
@@ -51,10 +61,10 @@ function MoodTrendChart({ data = [] }) {
     .join(" ");
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className={moodChartContainerClasses}>
       <svg
         viewBox={`0 0 ${width} ${height}`}
-        className="h-40 w-full"
+        className={moodChartVisualClasses}
         role="img"
       >
         <path d={path} fill="none" stroke="#047857" strokeWidth="2" />
@@ -68,18 +78,18 @@ function MoodTrendChart({ data = [] }) {
           />
         ))}
       </svg>
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className={moodChartLegendClasses}>
         {points.slice(-4).map((point) => (
-          <div key={point.date} className="flex items-center gap-3 rounded-2xl border border-emerald-100 bg-white/70 px-3 py-2">
+          <div key={point.date} className={moodChartLegendItemClasses}>
             <span
-              className="h-2.5 w-2.5 rounded-full"
+              className={moodChartLegendDotClasses}
               style={{ background: point.color }}
             />
-            <div className="space-y-1">
-              <p className="text-sm font-semibold text-emerald-900">
+            <div className={moodChartLegendCopyClasses}>
+              <p className={moodChartLegendLabelClasses}>
                 {point.label || "—"}
               </p>
-              <p className="text-xs text-emerald-900/60">
+              <p className={moodChartLegendDateClasses}>
                 {format(parseISO(point.date), "MMM d")}
               </p>
             </div>

--- a/frontend/src/components/PanicButton.js
+++ b/frontend/src/components/PanicButton.js
@@ -7,7 +7,23 @@ import {
   selectCompactClasses,
   textareaClasses,
   bodySmallMutedTextClasses,
-  bodySmallStrongTextClasses,
+  buttonPadSmClasses,
+  buttonPadXsClasses,
+  dialogActionsInlineClasses,
+  dialogBackdropClasses,
+  dialogBodyClasses,
+  dialogFieldClasses,
+  dialogFieldLabelClasses,
+  dialogFormClasses,
+  dialogHeaderClasses,
+  dialogHeadingGroupClasses,
+  dialogMessagesErrorClasses,
+  dialogMessagesSuccessClasses,
+  dialogPanelScrollClasses,
+  dialogPanelWideClasses,
+  dialogSubtitleClasses,
+  dialogTitleCompactClasses,
+  dialogCloseClasses,
 } from "../styles/ui";
 
 function PanicButton() {
@@ -113,7 +129,7 @@ function PanicButton() {
     <>
       <button
         type="button"
-        className={`${dangerButtonClasses} px-4 py-2 text-sm`}
+        className={`${dangerButtonClasses} ${buttonPadXsClasses}`}
         onClick={openDialog}
       >
         SOS
@@ -121,39 +137,36 @@ function PanicButton() {
 
       {isOpen && (
         <div
-          className="fixed inset-0 z-50 flex min-h-screen items-center justify-center bg-emerald-950/40 px-4 py-6 sm:px-6 sm:py-10"
+          className={dialogBackdropClasses}
           role="dialog"
           aria-modal="true"
           aria-labelledby="sos-dialog-heading"
           onClick={closeDialog}
         >
           <div
-            className="relative w-full max-w-lg overflow-hidden rounded-3xl bg-white shadow-2xl"
+            className={dialogPanelWideClasses}
             onClick={(event) => event.stopPropagation()}
           >
-            <div className="max-h-[min(85vh,40rem)] overflow-y-auto p-6 sm:p-8">
-              <div className="flex items-start justify-between gap-4">
-                <div className="space-y-1">
-                  <h2
-                    id="sos-dialog-heading"
-                    className="text-xl font-semibold text-emerald-900"
-                  >
+            <div className={dialogPanelScrollClasses}>
+              <div className={dialogHeaderClasses}>
+                <div className={dialogHeadingGroupClasses}>
+                  <h2 id="sos-dialog-heading" className={dialogTitleCompactClasses}>
                     Send a flare for support
                   </h2>
-                  <p className={bodySmallMutedTextClasses}>
+                  <p className={dialogSubtitleClasses}>
                     Choose a linked mentor and share why you need immediate care so they can arrive prepared.
                   </p>
                 </div>
                 <button
                   type="button"
-                  className={`${secondaryButtonClasses} px-4 py-2 text-sm`}
+                  className={`${secondaryButtonClasses} ${dialogCloseClasses}`}
                   onClick={closeDialog}
                 >
                   Close
                 </button>
               </div>
 
-              <div className="mt-6 space-y-4">
+              <div className={dialogBodyClasses}>
                 {loading && (
                   <p className={bodySmallMutedTextClasses}>Calling your mentors…</p>
                 )}
@@ -165,9 +178,9 @@ function PanicButton() {
                 )}
 
                 {hasContacts && (
-                  <form className="space-y-5" onSubmit={handleSubmit}>
-                    <div className="space-y-2">
-                      <label className={bodySmallStrongTextClasses} htmlFor="sos-mentor">
+                  <form className={dialogFormClasses} onSubmit={handleSubmit}>
+                    <div className={dialogFieldClasses}>
+                      <label className={dialogFieldLabelClasses} htmlFor="sos-mentor">
                         Reach out to
                       </label>
                       <select
@@ -186,8 +199,8 @@ function PanicButton() {
                       </select>
                     </div>
 
-                    <div className="space-y-2">
-                      <label className={bodySmallStrongTextClasses} htmlFor="sos-message">
+                    <div className={dialogFieldClasses}>
+                      <label className={dialogFieldLabelClasses} htmlFor="sos-message">
                         What do they need to know?
                       </label>
                       <textarea
@@ -202,17 +215,17 @@ function PanicButton() {
                     </div>
 
                     {error && (
-                      <p className="text-sm text-rose-600">{error}</p>
+                      <p className={dialogMessagesErrorClasses}>{error}</p>
                     )}
 
                     {success && (
-                      <p className="text-sm text-emerald-600">{success}</p>
+                      <p className={dialogMessagesSuccessClasses}>{success}</p>
                     )}
 
-                    <div className="flex justify-end gap-3">
+                    <div className={dialogActionsInlineClasses}>
                       <button
                         type="button"
-                        className={`${secondaryButtonClasses} px-5 py-2.5 text-sm`}
+                        className={`${secondaryButtonClasses} ${buttonPadSmClasses}`}
                         onClick={closeDialog}
                         disabled={sending}
                       >
@@ -220,7 +233,7 @@ function PanicButton() {
                       </button>
                       <button
                         type="submit"
-                        className={`${dangerButtonClasses} px-5 py-2.5 text-sm`}
+                        className={`${dangerButtonClasses} ${buttonPadSmClasses}`}
                         disabled={sending}
                       >
                         {sending ? "Sending…" : "Send SOS lantern"}
@@ -230,7 +243,7 @@ function PanicButton() {
                 )}
 
                 {error && !hasContacts && (
-                  <p className="text-sm text-rose-600">{error}</p>
+                  <p className={dialogMessagesErrorClasses}>{error}</p>
                 )}
               </div>
             </div>

--- a/frontend/src/components/SectionCard.js
+++ b/frontend/src/components/SectionCard.js
@@ -2,6 +2,14 @@ import {
   cardContainerClasses,
   sectionSubtitleClasses,
   sectionTitleClasses,
+  sectionCardActionsClasses,
+  sectionCardContentClasses,
+  sectionCardContentOffsetClasses,
+  sectionCardHeaderBetweenClasses,
+  sectionCardHeaderClasses,
+  sectionCardHeaderEndClasses,
+  sectionCardHeadingGroupClasses,
+  sectionCardIconClasses,
 } from "../styles/ui";
 
 function SectionCard({
@@ -20,30 +28,36 @@ function SectionCard({
   const headingClassName = [sectionTitleClasses, titleClassName]
     .filter(Boolean)
     .join(" ");
+  const headerAlignmentClass = showHeaderText
+    ? sectionCardHeaderBetweenClasses
+    : sectionCardHeaderEndClasses;
+  const headerClasses = `${sectionCardHeaderClasses} ${headerAlignmentClass}`.trim();
+  const contentClasses = [
+    sectionCardContentClasses,
+    showHeader ? sectionCardContentOffsetClasses : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <section ref={sectionRef} className={`${cardContainerClasses} w-full`}>
       {showHeader && (
-        <div
-          className={`flex flex-wrap items-center gap-4 ${
-            showHeaderText ? "justify-between" : "justify-end"
-          }`}
-        >
+        <div className={headerClasses}>
           {showHeaderText && (
-            <div className="space-y-1">
+            <div className={sectionCardHeadingGroupClasses}>
               <h2 ref={titleRef} className={headingClassName} {...restTitleProps}>
                 {icon && (
-                  <span className="mr-2 inline-flex items-center">{icon}</span>
+                  <span className={sectionCardIconClasses}>{icon}</span>
                 )}
                 {title}
               </h2>
               {subtitle && <p className={sectionSubtitleClasses}>{subtitle}</p>}
             </div>
           )}
-          {action && <div className="flex items-center gap-3">{action}</div>}
+          {action && <div className={sectionCardActionsClasses}>{action}</div>}
         </div>
       )}
-      <div className={`${showHeader ? "mt-6" : ""} space-y-4`}>{children}</div>
+      <div className={contentClasses}>{children}</div>
     </section>
   );
 }

--- a/frontend/src/components/TagInput.js
+++ b/frontend/src/components/TagInput.js
@@ -1,5 +1,16 @@
 import { useMemo, useState } from "react";
-import { chipBaseClasses, inputClasses } from "../styles/ui";
+import {
+  chipBaseClasses,
+  tagInputChipClasses,
+  tagInputContainerClasses,
+  tagInputEntryClasses,
+  tagInputFieldClasses,
+  tagInputGroupClasses,
+  tagInputLabelClasses,
+  tagInputRemoveButtonClasses,
+  tagInputSuggestionClasses,
+  tagInputSuggestionsContainerClasses,
+} from "../styles/ui";
 import { parseExpertise } from "../utils/expertise";
 
 function normaliseSuggestion(item) {
@@ -121,15 +132,15 @@ function TagInput({
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-emerald-200 bg-white/70 p-2 focus-within:border-emerald-300 focus-within:ring-2 focus-within:ring-emerald-100">
+    <div className={tagInputContainerClasses}>
+      <div className={tagInputFieldClasses}>
         {tags.map((tag) => (
-          <span key={tag} className={`${chipBaseClasses} flex items-center gap-2`}> 
+          <span key={tag} className={`${chipBaseClasses} ${tagInputChipClasses}`}>
             <span>{tag}</span>
             <button
               type="button"
               onClick={() => removeTag(tag)}
-              className="rounded-full bg-emerald-100 px-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-200"
+              className={tagInputRemoveButtonClasses}
               aria-label={`Remove ${tag}`}
             >
               ✕
@@ -141,22 +152,22 @@ function TagInput({
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
           onKeyDown={handleKeyDown}
-          className={`${inputClasses} h-9 min-w-[140px] flex-1 border-none bg-transparent px-2 py-1 text-sm shadow-none focus:ring-0 mt-0`}
+          className={tagInputEntryClasses}
           placeholder={placeholder}
         />
       </div>
       {(matchingSuggestions.length > 0 || topSuggestions.length > 0) && (
-        <div className="space-y-2">
+        <div className={tagInputSuggestionsContainerClasses}>
           {matchingSuggestions.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-emerald-800/70">
+            <div className={tagInputGroupClasses}>
+              <span className={tagInputLabelClasses}>
                 Matching expertise:
               </span>
               {matchingSuggestions.map((suggestion) => (
                 <button
                   key={`match-${suggestion}`}
                   type="button"
-                  className={`${chipBaseClasses} transition hover:bg-emerald-100`}
+                  className={`${chipBaseClasses} ${tagInputSuggestionClasses}`}
                   onClick={() => addTag(suggestion)}
                 >
                   {suggestion}
@@ -165,15 +176,15 @@ function TagInput({
             </div>
           )}
           {topSuggestions.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-emerald-800/70">
+            <div className={tagInputGroupClasses}>
+              <span className={tagInputLabelClasses}>
                 Popular expertise:
               </span>
               {topSuggestions.map((suggestion) => (
                 <button
                   key={`top-${suggestion}`}
                   type="button"
-                  className={`${chipBaseClasses} transition hover:bg-emerald-100`}
+                  className={`${chipBaseClasses} ${tagInputSuggestionClasses}`}
                   onClick={() => addTag(suggestion)}
                 >
                   {suggestion}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,6 +43,18 @@
     @apply inline-flex h-11 w-11 items-center justify-center rounded-full border border-emerald-200 bg-white/80 text-emerald-700 shadow-sm shadow-emerald-900/10 transition hover:border-emerald-300 hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600;
   }
 
+  .icon-sm {
+    @apply h-5 w-5;
+  }
+
+  .btn-primary-compact {
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-emerald-600/20 transition hover:-translate-y-0.5 hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
+  }
+
+  .btn-secondary-compact {
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-emerald-200 bg-white/70 px-5 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm shadow-emerald-900/10 transition hover:-translate-y-0.5 hover:border-emerald-300 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
+  }
+
   .form-input {
     @apply mt-2 w-full rounded-2xl border border-emerald-100 bg-white/90 px-4 py-3 text-base text-emerald-900 shadow-sm transition placeholder:text-emerald-900/40 focus:border-emerald-400 focus:outline-none focus:ring-4 focus:ring-emerald-100;
   }
@@ -159,7 +171,583 @@
     @apply text-xs font-semibold uppercase tracking-wide;
   }
 
+  .text-preline {
+    @apply whitespace-pre-line;
+  }
+
+  .metric-card {
+    @apply rounded-2xl border border-emerald-100 bg-white/70 p-5 shadow-inner shadow-emerald-900/5;
+  }
+
+  .metric-card__label {
+    @apply text-xs font-semibold uppercase tracking-wide text-emerald-900/60;
+  }
+
+  .metric-card__value {
+    @apply mt-3 text-3xl font-bold text-emerald-900;
+  }
+
+  .metric-card__description {
+    @apply mt-2 text-sm text-emerald-900/70;
+  }
+
+  .metric-card__details {
+    @apply mt-4 text-sm text-emerald-900/70;
+  }
+
+  .request-list {
+    @apply grid gap-4;
+  }
+
+  .request-card {
+    @apply flex flex-wrap items-start justify-between gap-4 rounded-2xl border border-emerald-100 bg-white/70 p-5;
+  }
+
+  .request-card__body {
+    @apply space-y-1 text-emerald-900;
+  }
+
+  .request-card__title {
+    @apply text-base font-semibold;
+  }
+
+  .request-card__status {
+    @apply text-sm;
+  }
+
+  .request-card__message {
+    @apply text-sm text-emerald-900/70;
+  }
+
+  .request-card__actions {
+    @apply flex flex-wrap items-center gap-3;
+  }
+
+  .tag-input {
+    @apply space-y-3;
+  }
+
+  .tag-input__field {
+    @apply flex flex-wrap items-center gap-2 rounded-2xl border border-emerald-200 bg-white/70 p-2 focus-within:border-emerald-300 focus-within:ring-2 focus-within:ring-emerald-100;
+  }
+
+  .tag-input__chip {
+    @apply flex items-center gap-2;
+  }
+
+  .tag-input__remove {
+    @apply rounded-full bg-emerald-100 px-1 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-200;
+  }
+
+  .tag-input__entry {
+    @apply h-9 min-w-[140px] flex-1 border-none bg-transparent px-2 py-1 text-sm text-emerald-900 placeholder:text-emerald-900/40 focus:outline-none focus:ring-0;
+  }
+
+  .tag-input__label {
+    @apply text-xs font-semibold uppercase tracking-wide text-emerald-800/70;
+  }
+
+  .tag-input__suggestion {
+    @apply transition hover:bg-emerald-100;
+  }
+
+  .tag-input__suggestions {
+    @apply space-y-2;
+  }
+
+  .tag-input__group {
+    @apply flex flex-wrap items-center gap-2;
+  }
+
+  .loading-state {
+    @apply flex items-center justify-center text-sm font-medium text-emerald-900/70;
+  }
+
+  .loading-state--full {
+    @apply min-h-[40vh];
+  }
+
+  .mood-chart {
+    @apply flex flex-col gap-4;
+  }
+
+  .mood-chart__visual {
+    @apply h-40 w-full;
+  }
+
+  .mood-chart__legend {
+    @apply grid gap-3 sm:grid-cols-2;
+  }
+
+  .mood-chart__legend-item {
+    @apply flex items-center gap-3 rounded-2xl border border-emerald-100 bg-white/70 px-3 py-2;
+  }
+
+  .mood-chart__legend-dot {
+    @apply h-2.5 w-2.5 rounded-full;
+  }
+
+  .mood-chart__legend-label {
+    @apply text-sm font-semibold text-emerald-900;
+  }
+
+  .mood-chart__legend-date {
+    @apply text-xs text-emerald-900/60;
+  }
+
   .form-label {
-    @apply text-sm font-semibold text-emerald-900/80;
+    @apply block text-sm font-semibold text-emerald-900/80;
+  }
+
+  .stack-xs {
+    @apply space-y-1;
+  }
+
+  .stack-sm {
+    @apply space-y-2;
+  }
+
+  .stack-md {
+    @apply space-y-3;
+  }
+
+  .stack-lg {
+    @apply space-y-4;
+  }
+
+  .stack-xl {
+    @apply space-y-5;
+  }
+
+  .cluster-inline {
+    @apply flex items-center gap-3;
+  }
+
+  .cluster-inline-tight {
+    @apply flex items-center gap-2;
+  }
+
+  .cluster-wrap {
+    @apply flex flex-wrap items-center gap-3;
+  }
+
+  .cluster-wrap-tight {
+    @apply flex flex-wrap items-center gap-2;
+  }
+
+  .cluster-center {
+    @apply flex flex-wrap justify-center gap-3;
+  }
+
+  .cluster-end {
+    @apply flex flex-wrap justify-end gap-3;
+  }
+
+  .cluster-between {
+    @apply flex flex-wrap items-center justify-between gap-4;
+  }
+
+  .app-shell {
+    @apply flex min-h-screen flex-col bg-gradient-to-br from-emerald-50 via-white to-emerald-100 text-emerald-950;
+  }
+
+  .app-header {
+    @apply sticky top-0 z-30 border-b border-emerald-100 bg-white/85 backdrop-blur;
+  }
+
+  .app-header__inner {
+    @apply relative mx-auto w-full max-w-6xl px-6 py-3;
+  }
+
+  .app-header__row {
+    @apply flex w-full items-center gap-3;
+  }
+
+  .app-brand {
+    @apply rounded-full border border-transparent bg-transparent text-heading-lg leading-none tracking-tight text-emerald-700 transition hover:text-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600;
+  }
+
+  .primary-nav {
+    @apply hidden flex-1 items-center justify-center gap-1 text-body-sm-strong text-emerald-900/70 md:flex;
+  }
+
+  .primary-nav__link {
+    @apply rounded-full px-4 py-2 transition;
+  }
+
+  .primary-nav__link--active {
+    @apply bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10;
+  }
+
+  .primary-nav__link--inactive {
+    @apply text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700;
+  }
+
+  .header-actions {
+    @apply hidden items-center gap-3 md:flex;
+  }
+
+  .mobile-actions {
+    @apply ml-auto flex items-center gap-3 md:hidden;
+  }
+
+  .mobile-actions__toggle--active {
+    @apply bg-emerald-600 text-white hover:text-white;
+  }
+
+  .mobile-menu {
+    @apply absolute left-0 right-0 top-full mt-3 md:hidden;
+  }
+
+  .mobile-menu__panel {
+    @apply rounded-3xl border border-emerald-100 bg-white/95 p-4 shadow-xl shadow-emerald-900/10 backdrop-blur;
+  }
+
+  .mobile-nav {
+    @apply flex flex-col gap-2 text-body-sm-strong text-emerald-900/80;
+  }
+
+  .mobile-nav__link {
+    @apply rounded-full px-4 py-2 transition;
+  }
+
+  .mobile-nav__link--active {
+    @apply bg-emerald-100 text-emerald-800 shadow-inner shadow-emerald-900/10;
+  }
+
+  .mobile-nav__link--inactive {
+    @apply text-emerald-900/70 hover:bg-emerald-50 hover:text-emerald-700;
+  }
+
+  .mobile-menu__divider {
+    @apply mt-4 border-t border-emerald-100/70 pt-4;
+  }
+
+  .app-main {
+    @apply mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-12;
+  }
+
+  .app-footer {
+    @apply border-t border-emerald-100 bg-white/70;
+  }
+
+  .app-footer__content {
+    @apply mx-auto w-full max-w-6xl px-6 py-6 text-center text-body-sm text-emerald-900/70;
+  }
+
+  .auth-controls {
+    @apply flex flex-wrap items-center gap-3;
+  }
+
+  .auth-controls--vertical {
+    @apply flex flex-col gap-3;
+  }
+
+  .auth-controls__text {
+    @apply text-right;
+  }
+
+  .auth-controls__text--vertical {
+    @apply text-left;
+  }
+
+  .auth-controls__name {
+    @apply block text-body-sm-strong text-emerald-900;
+  }
+
+  .auth-controls__role {
+    @apply text-caption text-emerald-900/60;
+  }
+
+  .button-pad-xs {
+    @apply px-4 py-2 text-sm;
+  }
+
+  .button-pad-sm {
+    @apply px-5 py-2.5 text-sm;
+  }
+
+  .button-pad-md {
+    @apply px-6 py-2.5;
+  }
+
+  .button-block {
+    @apply w-full justify-center;
+  }
+
+  .button-fluid {
+    @apply w-full;
+  }
+
+  .button-responsive {
+    @apply w-full sm:w-auto;
+  }
+
+  .error-shell {
+    @apply flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-emerald-100 px-6 py-16;
+  }
+
+  .error-panel {
+    @apply w-full max-w-xl rounded-3xl border border-emerald-200/70 bg-white/80 p-10 text-center shadow-lg shadow-emerald-200/50 backdrop-blur;
+  }
+
+  .error-heading {
+    @apply text-heading-lg text-emerald-900;
+  }
+
+  .error-copy {
+    @apply mt-4 text-body text-emerald-900/80;
+  }
+
+  .error-actions {
+    @apply cluster-center mt-8;
+  }
+
+  .error-details {
+    @apply mt-8 text-left;
+  }
+
+  .error-details__toggle {
+    @apply text-body underline-offset-4 transition hover:underline;
+  }
+
+  .error-details__panel {
+    @apply mt-4 max-h-48 overflow-auto rounded-2xl bg-emerald-50/80 p-4 text-body-sm leading-relaxed text-emerald-900/70;
+  }
+
+  .error-footer {
+    @apply mt-8 text-body-sm text-emerald-900/70;
+  }
+
+  .dialog-backdrop {
+    @apply fixed inset-0 z-50 flex min-h-screen items-center justify-center bg-emerald-950/40 px-4 py-6 sm:px-6 sm:py-10;
+  }
+
+  .dialog-panel {
+    @apply relative w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl sm:p-8;
+  }
+
+  .dialog-panel--wide {
+    @apply relative w-full max-w-lg overflow-hidden rounded-3xl bg-white shadow-2xl;
+  }
+
+  .dialog-panel__scroll {
+    @apply max-h-[min(85vh,40rem)] overflow-y-auto p-6 sm:p-8;
+  }
+
+  .dialog-header {
+    @apply cluster-between;
+  }
+
+  .dialog-heading-group {
+    @apply stack-xs;
+  }
+
+  .dialog-title {
+    @apply text-heading-md text-emerald-900;
+  }
+
+  .dialog-title--compact {
+    @apply text-heading-sm text-emerald-900;
+  }
+
+  .dialog-subtitle {
+    @apply text-body-sm text-emerald-900/70;
+  }
+
+  .dialog-close {
+    @apply button-pad-xs text-sm;
+  }
+
+  .dialog-body {
+    @apply mt-6 stack-lg;
+  }
+
+  .dialog-section {
+    @apply stack-sm;
+  }
+
+  .dialog-section__title {
+    @apply text-caption text-emerald-800/70;
+  }
+
+  .dialog-actions {
+    @apply cluster-end mt-8;
+  }
+
+  .mentor-dialog__chips {
+    @apply cluster-wrap-tight;
+  }
+
+  .dialog-form {
+    @apply stack-xl;
+  }
+
+  .dialog-field {
+    @apply stack-sm;
+  }
+
+  .dialog-field__label {
+    @apply text-body-sm-strong text-emerald-900;
+  }
+
+  .dialog-messages__error {
+    @apply text-body-sm text-rose-600;
+  }
+
+  .dialog-messages__success {
+    @apply text-body-sm text-emerald-600;
+  }
+
+  .dialog-actions--inline {
+    @apply cluster-end;
+  }
+
+  .section-card__header {
+    @apply flex flex-wrap items-center gap-4;
+  }
+
+  .section-card__header--between {
+    @apply justify-between;
+  }
+
+  .section-card__header--end {
+    @apply justify-end;
+  }
+
+  .section-card__heading-group {
+    @apply stack-xs;
+  }
+
+  .section-card__icon {
+    @apply mr-2 inline-flex items-center;
+  }
+
+  .section-card__actions {
+    @apply flex items-center gap-3;
+  }
+
+  .section-card__content {
+    @apply stack-lg;
+  }
+
+  .section-card__content--offset {
+    @apply mt-6;
+  }
+
+  .form-stack {
+    @apply stack-xl;
+  }
+
+  .form-section {
+    @apply stack-sm;
+  }
+
+  .form-helper {
+    @apply text-body-sm text-emerald-900/60;
+  }
+
+  .form-required {
+    @apply ml-1 text-rose-500;
+  }
+
+  .form-status {
+    @apply rounded-2xl px-4 py-3 text-body-sm-strong;
+  }
+
+  .form-status--error {
+    @apply border border-rose-100 bg-rose-50/80 text-rose-600;
+  }
+
+  .form-status--success {
+    @apply border border-emerald-100 bg-emerald-50/80 text-emerald-700;
+  }
+
+  .form-status--info {
+    @apply border border-emerald-100 bg-white/80 text-emerald-900/70;
+  }
+
+  .form-actions {
+    @apply flex flex-col gap-3 sm:flex-row;
+  }
+
+  .request-status--pending {
+    @apply text-emerald-900/70;
+  }
+
+  .request-status--mentor_accepted {
+    @apply text-amber-600;
+  }
+
+  .request-status--confirmed {
+    @apply text-emerald-600;
+  }
+
+  .request-status--declined {
+    @apply text-rose-600;
+  }
+
+  .request-status--ended {
+    @apply text-slate-500;
+  }
+
+  .mood-chart__legend-copy {
+    @apply stack-xs;
+  }
+
+  .badge-mood-happy {
+    @apply bg-emerald-100 text-emerald-700;
+  }
+
+  .badge-mood-loved {
+    @apply bg-pink-100 text-pink-700;
+  }
+
+  .badge-mood-proud {
+    @apply bg-amber-100 text-amber-700;
+  }
+
+  .badge-mood-relaxed {
+    @apply bg-teal-100 text-teal-700;
+  }
+
+  .badge-mood-tired {
+    @apply bg-slate-200 text-slate-700;
+  }
+
+  .badge-mood-anxious {
+    @apply bg-rose-100 text-rose-700;
+  }
+
+  .badge-mood-angry {
+    @apply bg-rose-100 text-rose-700;
+  }
+
+  .badge-mood-sad {
+    @apply bg-sky-100 text-sky-700;
+  }
+
+  .badge-mood-neutral {
+    @apply bg-emerald-100 text-emerald-700;
+  }
+
+  .chip-share-private {
+    @apply bg-slate-100 text-slate-600;
+  }
+
+  .chip-share-mood {
+    @apply bg-sky-100 text-sky-700;
+  }
+
+  .chip-share-summary {
+    @apply bg-amber-100 text-amber-700;
+  }
+
+  .chip-share-full {
+    @apply bg-emerald-100 text-emerald-700;
+  }
+
+  .chip-share-default {
+    @apply bg-emerald-50 text-emerald-700;
   }
 }

--- a/frontend/src/styles/ui.js
+++ b/frontend/src/styles/ui.js
@@ -3,6 +3,9 @@ export const dangerButtonClasses = "btn-danger";
 export const secondaryButtonClasses = "btn-secondary";
 export const subtleButtonClasses = "btn-subtle";
 export const iconButtonClasses = "icon-button";
+export const iconSmallClasses = "icon-sm";
+export const primaryButtonCompactClasses = "btn-primary-compact";
+export const secondaryButtonCompactClasses = "btn-secondary-compact";
 
 export const inputClasses = "form-input";
 export const inputCompactClasses = "form-input-compact";
@@ -23,6 +26,140 @@ export const tableRowClasses = "table-row";
 export const cardContainerClasses = "card-container";
 export const sectionTitleClasses = "section-title";
 export const sectionSubtitleClasses = "section-subtitle";
+export const metricCardClasses = "metric-card";
+export const metricCardLabelClasses = "metric-card__label";
+export const metricCardValueClasses = "metric-card__value";
+export const metricCardDescriptionClasses = "metric-card__description";
+export const metricCardDetailsClasses = "metric-card__details";
+export const requestListClasses = "request-list";
+export const requestCardClasses = "request-card";
+export const requestCardBodyClasses = "request-card__body";
+export const requestCardTitleClasses = "request-card__title";
+export const requestCardStatusClasses = "request-card__status";
+export const requestCardMessageClasses = "request-card__message";
+export const requestCardActionsClasses = "request-card__actions";
+export const tagInputContainerClasses = "tag-input";
+export const tagInputFieldClasses = "tag-input__field";
+export const tagInputChipClasses = "tag-input__chip";
+export const tagInputRemoveButtonClasses = "tag-input__remove";
+export const tagInputEntryClasses = "tag-input__entry";
+export const tagInputLabelClasses = "tag-input__label";
+export const tagInputSuggestionClasses = "tag-input__suggestion";
+export const tagInputSuggestionsContainerClasses = "tag-input__suggestions";
+export const tagInputGroupClasses = "tag-input__group";
+export const loadingStateClasses = "loading-state";
+export const loadingStateFullClasses = "loading-state--full";
+export const moodChartContainerClasses = "mood-chart";
+export const moodChartVisualClasses = "mood-chart__visual";
+export const moodChartLegendClasses = "mood-chart__legend";
+export const moodChartLegendItemClasses = "mood-chart__legend-item";
+export const moodChartLegendDotClasses = "mood-chart__legend-dot";
+export const moodChartLegendLabelClasses = "mood-chart__legend-label";
+export const moodChartLegendDateClasses = "mood-chart__legend-date";
+export const moodChartLegendCopyClasses = "mood-chart__legend-copy";
+
+export const stackXsClasses = "stack-xs";
+export const stackSmClasses = "stack-sm";
+export const stackMdClasses = "stack-md";
+export const stackLgClasses = "stack-lg";
+export const stackXlClasses = "stack-xl";
+
+export const clusterInlineClasses = "cluster-inline";
+export const clusterInlineTightClasses = "cluster-inline-tight";
+export const clusterWrapClasses = "cluster-wrap";
+export const clusterWrapTightClasses = "cluster-wrap-tight";
+export const clusterCenterClasses = "cluster-center";
+export const clusterEndClasses = "cluster-end";
+export const clusterBetweenClasses = "cluster-between";
+
+export const appShellClasses = "app-shell";
+export const appHeaderClasses = "app-header";
+export const appHeaderInnerClasses = "app-header__inner";
+export const appHeaderRowClasses = "app-header__row";
+export const appBrandClasses = "app-brand";
+export const primaryNavClasses = "primary-nav";
+export const primaryNavLinkClasses = "primary-nav__link";
+export const primaryNavLinkActiveClasses = "primary-nav__link--active";
+export const primaryNavLinkInactiveClasses = "primary-nav__link--inactive";
+export const headerActionsClasses = "header-actions";
+export const mobileActionsClasses = "mobile-actions";
+export const mobileActionsToggleActiveClasses = "mobile-actions__toggle--active";
+export const mobileMenuClasses = "mobile-menu";
+export const mobileMenuPanelClasses = "mobile-menu__panel";
+export const mobileNavClasses = "mobile-nav";
+export const mobileNavLinkClasses = "mobile-nav__link";
+export const mobileNavLinkActiveClasses = "mobile-nav__link--active";
+export const mobileNavLinkInactiveClasses = "mobile-nav__link--inactive";
+export const mobileMenuDividerClasses = "mobile-menu__divider";
+export const appMainClasses = "app-main";
+export const appFooterClasses = "app-footer";
+export const appFooterContentClasses = "app-footer__content";
+
+export const authControlsClasses = "auth-controls";
+export const authControlsVerticalClasses = "auth-controls--vertical";
+export const authControlsTextClasses = "auth-controls__text";
+export const authControlsTextVerticalClasses = "auth-controls__text--vertical";
+export const authControlsNameClasses = "auth-controls__name";
+export const authControlsRoleClasses = "auth-controls__role";
+
+export const buttonPadXsClasses = "button-pad-xs";
+export const buttonPadSmClasses = "button-pad-sm";
+export const buttonPadMdClasses = "button-pad-md";
+export const buttonBlockClasses = "button-block";
+export const buttonFluidClasses = "button-fluid";
+export const buttonResponsiveClasses = "button-responsive";
+
+export const errorShellClasses = "error-shell";
+export const errorPanelClasses = "error-panel";
+export const errorHeadingClasses = "error-heading";
+export const errorCopyClasses = "error-copy";
+export const errorActionsClasses = "error-actions";
+export const errorDetailsClasses = "error-details";
+export const errorDetailsToggleClasses = "error-details__toggle";
+export const errorDetailsPanelClasses = "error-details__panel";
+export const errorFooterClasses = "error-footer";
+
+export const dialogBackdropClasses = "dialog-backdrop";
+export const dialogPanelClasses = "dialog-panel";
+export const dialogPanelWideClasses = "dialog-panel--wide";
+export const dialogPanelScrollClasses = "dialog-panel__scroll";
+export const dialogHeaderClasses = "dialog-header";
+export const dialogHeadingGroupClasses = "dialog-heading-group";
+export const dialogTitleClasses = "dialog-title";
+export const dialogTitleCompactClasses = "dialog-title--compact";
+export const dialogSubtitleClasses = "dialog-subtitle";
+export const dialogCloseClasses = "dialog-close";
+export const dialogBodyClasses = "dialog-body";
+export const dialogSectionClasses = "dialog-section";
+export const dialogSectionTitleClasses = "dialog-section__title";
+export const dialogActionsClasses = "dialog-actions";
+export const mentorDialogChipsClasses = "mentor-dialog__chips";
+export const dialogFormClasses = "dialog-form";
+export const dialogFieldClasses = "dialog-field";
+export const dialogFieldLabelClasses = "dialog-field__label";
+export const dialogMessagesErrorClasses = "dialog-messages__error";
+export const dialogMessagesSuccessClasses = "dialog-messages__success";
+export const dialogActionsInlineClasses = "dialog-actions--inline";
+
+export const sectionCardHeaderClasses = "section-card__header";
+export const sectionCardHeaderBetweenClasses = "section-card__header--between";
+export const sectionCardHeaderEndClasses = "section-card__header--end";
+export const sectionCardHeadingGroupClasses = "section-card__heading-group";
+export const sectionCardIconClasses = "section-card__icon";
+export const sectionCardActionsClasses = "section-card__actions";
+export const sectionCardContentClasses = "section-card__content";
+export const sectionCardContentOffsetClasses = "section-card__content--offset";
+
+export const formStackClasses = "form-stack";
+export const formSectionClasses = "form-section";
+export const formHelperClasses = "form-helper";
+export const formRequiredClasses = "form-required";
+export const formStatusClasses = "form-status";
+export const formStatusErrorClasses = "form-status--error";
+export const formStatusSuccessClasses = "form-status--success";
+export const formStatusInfoClasses = "form-status--info";
+export const formActionsClasses = "form-actions";
+export const srOnlyClasses = "sr-only";
 
 export const displayTextClasses = "text-display";
 export const largeHeadingClasses = "text-heading-lg";
@@ -37,48 +174,49 @@ export const bodySmallMutedTextClasses = "text-muted";
 export const eyebrowTextClasses = "text-eyebrow";
 export const captionTextClasses = "text-caption";
 export const formLabelClasses = "form-label";
+export const textPreLineClasses = "text-preline";
 
 const moodClassMap = {
-  happy: "bg-emerald-100 text-emerald-700",
-  loved: "bg-pink-100 text-pink-700",
-  proud: "bg-amber-100 text-amber-700",
-  relaxed: "bg-teal-100 text-teal-700",
-  tired: "bg-slate-200 text-slate-700",
-  anxious: "bg-rose-100 text-rose-700",
-  angry: "bg-rose-100 text-rose-700",
-  sad: "bg-sky-100 text-sky-700",
-  neutral: "bg-emerald-100 text-emerald-700",
+  happy: "badge-mood-happy",
+  loved: "badge-mood-loved",
+  proud: "badge-mood-proud",
+  relaxed: "badge-mood-relaxed",
+  tired: "badge-mood-tired",
+  anxious: "badge-mood-anxious",
+  angry: "badge-mood-angry",
+  sad: "badge-mood-sad",
+  neutral: "badge-mood-neutral",
 };
 
 export function getMoodBadgeClasses(mood) {
   const key = mood?.toString().toLowerCase();
-  const tone = moodClassMap[key] || moodClassMap.neutral;
+  const tone = moodClassMap[key] || "badge-mood-neutral";
   return `${badgeBaseClasses} ${tone}`.trim();
 }
 
 const shareClassMap = {
-  private: "bg-slate-100 text-slate-600",
-  mood: "bg-sky-100 text-sky-700",
-  summary: "bg-amber-100 text-amber-700",
-  full: "bg-emerald-100 text-emerald-700",
+  private: "chip-share-private",
+  mood: "chip-share-mood",
+  summary: "chip-share-summary",
+  full: "chip-share-full",
 };
 
 export function getShareChipClasses(level = "default") {
-  const tone = shareClassMap[level] || "bg-emerald-50 text-emerald-700";
+  const tone = shareClassMap[level] || "chip-share-default";
   return `${chipBaseClasses} ${tone}`.trim();
 }
 
 export function getStatusToneClasses(status) {
   switch (status) {
     case "mentor_accepted":
-      return "text-amber-600";
+      return "request-status--mentor_accepted";
     case "confirmed":
-      return "text-emerald-600";
+      return "request-status--confirmed";
     case "declined":
-      return "text-rose-600";
+      return "request-status--declined";
     case "ended":
-      return "text-slate-500";
+      return "request-status--ended";
     default:
-      return "text-emerald-900/70";
+      return "request-status--pending";
   }
 }


### PR DESCRIPTION
## Summary
- centralize layout, dialog, form, and status styling as tokens in the shared Tailwind layer and re-export them through `styles/ui`
- refactor Layout, GlobalErrorBoundary, MentorProfileDialog, PanicButton, SectionCard, JournalEntryForm, and MoodTrendChart to consume the new tokens instead of inline Tailwind utilities
- refresh the frontend component and theme guides to document the expanded token set and dependencies

## Testing
- npm test -- --watchAll=false --passWithNoTests