### PR TITLE
Keep button link text white on hover

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,6 +27,13 @@
     @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-emerald-600/20 transition hover:-translate-y-0.5 hover:bg-emerald-500 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:translate-y-0 disabled:opacity-60;
   }
 
+  a.btn-primary:hover,
+  a.btn-primary:focus-visible,
+  a.btn-primary-compact:hover,
+  a.btn-primary-compact:focus-visible {
+    @apply text-white;
+  }
+
   .btn-danger {
     @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-rose-600 px-6 py-3.5 text-base font-semibold text-white shadow-lg shadow-rose-500/20 transition hover:-translate-y-0.5 hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500 disabled:translate-y-0 disabled:opacity-60;
   }


### PR DESCRIPTION
## Summary
- restore the global link hover styling so non-button links keep their underline and emerald tint
- explicitly force `.btn-primary` anchor variants (including compact) to keep white text while hovered or focus-visible

## Testing
- npm run build --prefix frontend
