### PR TITLE
fix: polish mentor form updates and docs

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,0 +1,6 @@
+# Backend Change Log
+
+## Mentor form stewardship (2025-09-21)
+- Mentors can now update their custom forms via `PUT /api/forms/:formId`. The handler validates ownership, replaces the field definitions inside a transaction, and keeps default templates locked down.
+- Mentors can now delete their own forms with `DELETE /api/forms/:formId`. The route rejects attempts against default templates or forms created by other users.
+- Frontend builder now loads mentor forms for editing, lets guides refresh prompts, and surfaces delete controls that call the new endpoints.

--- a/docs/backend/endpoints.md
+++ b/docs/backend/endpoints.md
@@ -53,9 +53,14 @@
 - **Request:** `{ title, description?, fields: [{ label, fieldType, required?, options?, helperText? }], visibility? }`
 - **Response:** `201` with `{ form }` newly created (visibility defaults to `mentor`).
 
+### PUT /api/forms/:id
+- **Auth:** Mentor (owner)
+- **Request:** `{ title, description?, fields: [{ label, fieldType, required?, options?, helperText? }] }`
+- **Response:** `{ form }` with refreshed prompts once ownership is confirmed; default templates remain locked.
+
 ### DELETE /api/forms/:id
 - **Auth:** Mentor (owner)
-- **Response:** `{ success: true }` once the mentor-owned form is removed.
+- **Response:** `{ success: true }` once the mentor-owned, non-default form is removed.
 
 ### POST /api/forms/:formId/assign
 - **Auth:** Mentor (owner)
@@ -67,9 +72,8 @@
 - **Response:** `{ success: true }` removing a specific mentee assignment.
 
 ### DELETE /api/forms/:formId/assignment
-- **Auth:** Mentor (owner)
-- **Query:** `journalerId`
-- **Response:** `{ success: true }` fallback for removing a mentee when the composite id is not known client-side.
+- **Auth:** Journaler (self)
+- **Response:** `{ success: true }` when a journaler unlinks a non-default form from their dashboard.
 
 ## Journal Entries
 ### POST /api/journal-entries

--- a/docs/frontend/pages.md
+++ b/docs/frontend/pages.md
@@ -71,7 +71,7 @@
 - **Route:** `/forms`
 - **Components:** Mentor form composer for creation; admin stewardship table of all forms and mentee assignments.
 - **APIs:**
-  - Mentor: `GET /api/forms`, `POST /api/forms` to create new prompts, `DELETE /api/forms/:id` to archive mentor-authored templates, `POST /api/forms/:formId/assign` to map mentees, `DELETE /api/forms/:formId/assign/:journalerId` or `DELETE /api/forms/:formId/assignment` to unassign.
+  - Mentor: `GET /api/forms`, `POST /api/forms` to create new prompts, `PUT /api/forms/:id` to refresh existing templates, `DELETE /api/forms/:id` to archive mentor-authored templates, `POST /api/forms/:formId/assign` to map mentees, `DELETE /api/forms/:formId/assign/:journalerId` to unlink mentees.
   - Admin: `GET /api/admin/forms`, `PATCH /api/admin/forms/:id` to update visibility/flags, `DELETE /api/admin/forms/:id` to remove non-default forms.
 
 ## SettingsPage

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -43,6 +43,8 @@ const apiClient = {
   get: (path, token, config = {}) => request(path, { ...config, method: "GET", token }),
   post: (path, data, token, config = {}) =>
     request(path, { ...config, method: "POST", data, token }),
+  put: (path, data, token, config = {}) =>
+    request(path, { ...config, method: "PUT", data, token }),
   patch: (path, data, token, config = {}) =>
     request(path, { ...config, method: "PATCH", data, token }),
   del: (path, token, config = {}) => {

--- a/frontend/src/pages/FormBuilderPage.js
+++ b/frontend/src/pages/FormBuilderPage.js
@@ -40,11 +40,7 @@ function FormBuilderPage() {
   const [mentees, setMentees] = useState([]);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState(null);
-  const [formDraft, setFormDraft] = useState({
-    title: "",
-    description: "",
-    fields: [createField()],
-  });
+  const [formDraft, setFormDraft] = useState(() => createEmptyDraft());
   const [optionDrafts, setOptionDrafts] = useState({});
   const [assignment, setAssignment] = useState({ menteeId: "", formId: "" });
   const [searchTerm, setSearchTerm] = useState(() => searchParams.get("q") || "");
@@ -61,8 +57,10 @@ function FormBuilderPage() {
   );
   const isAdmin = user.role === "admin";
   const isMentor = user.role === "mentor";
+  const [editingFormId, setEditingFormId] = useState(null);
   const adminTableGridTemplate =
     "minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1.5fr) auto";
+  const isEditing = editingFormId !== null;
 
   const load = useCallback(async () => {
     if (!token) return;
@@ -85,6 +83,54 @@ function FormBuilderPage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  const editingForm = useMemo(() => {
+    if (!editingFormId) {
+      return null;
+    }
+
+    return forms.find((form) => form.id === editingFormId) || null;
+  }, [editingFormId, forms]);
+
+  const resetFormDraft = useCallback(() => {
+    setFormDraft(createEmptyDraft());
+    setOptionDrafts({});
+    setEditingFormId(null);
+  }, [setFormDraft, setOptionDrafts, setEditingFormId]);
+
+  const beginEditingForm = useCallback(
+    (form) => {
+      const nextFields = Array.isArray(form.fields) && form.fields.length
+        ? form.fields.map((field) => {
+            const options = parseFieldOptions(field.options);
+
+            return {
+              uiId: `field-${nextFieldId++}`,
+              label: field.label || "",
+              fieldType: field.fieldType || "textarea",
+              required: Boolean(field.required),
+              helperText: field.helperText || "",
+              options,
+            };
+          })
+        : [createField()];
+
+      setFormDraft({
+        title: form.title || "",
+        description: form.description || "",
+        fields: nextFields,
+      });
+      setOptionDrafts({});
+      setEditingFormId(form.id);
+      setMessage(`Editing "${form.title}".`);
+    },
+    [setFormDraft, setOptionDrafts, setEditingFormId, setMessage]
+  );
+
+  const handleCancelEdit = useCallback(() => {
+    resetFormDraft();
+    setMessage(null);
+  }, [resetFormDraft, setMessage]);
 
   useEffect(() => {
     const nextSearch = searchParams.get("q") || "";
@@ -254,18 +300,24 @@ function FormBuilderPage() {
   }, []);
 
   const handleDeleteForm = useCallback(
-    async (formId) => {
+    async (form) => {
       if (!token) return;
 
+      const endpoint =
+        user.role === "admin" ? `/admin/forms/${form.id}` : `/forms/${form.id}`;
+
       try {
-        await apiClient.del(`/admin/forms/${formId}`, token);
+        await apiClient.del(endpoint, token);
+        if (editingFormId === form.id) {
+          resetFormDraft();
+        }
         await load();
         setMessage("Form deleted successfully.");
       } catch (err) {
         setMessage(err.message);
       }
     },
-    [load, token]
+    [editingFormId, load, resetFormDraft, token, user.role]
   );
 
   const handleRemoveAssignment = useCallback(
@@ -363,28 +415,39 @@ function FormBuilderPage() {
     }));
   };
 
-  const handleCreateForm = async (event) => {
+  const handleSubmitForm = async (event) => {
     event.preventDefault();
-    try {
-      const payload = {
-        ...formDraft,
-        fields: formDraft.fields.map((field) => ({
-          label: field.label,
-          fieldType: field.fieldType,
-          required: field.required,
-          helperText: field.helperText,
-          options:
-            field.fieldType === "select"
-              ? normalizeOptionList(field.options)
-              : [],
-        })),
-      };
+    if (!token) return;
 
-      await apiClient.post("/forms", payload, token);
-      setFormDraft({ title: "", description: "", fields: [createField()] });
-      setOptionDrafts({});
+    const payload = {
+      title: formDraft.title,
+      description: formDraft.description,
+      fields: formDraft.fields.map((field) => ({
+        label: field.label,
+        fieldType: field.fieldType,
+        required: field.required,
+        helperText: field.helperText,
+        options:
+          field.fieldType === "select"
+            ? normalizeOptionList(field.options)
+            : [],
+      })),
+    };
+
+    const successMessage = isEditing
+      ? "Form updated successfully."
+      : "Form created successfully.";
+
+    try {
+      if (isEditing && editingFormId) {
+        await apiClient.put(`/forms/${editingFormId}`, payload, token);
+      } else {
+        await apiClient.post("/forms", payload, token);
+      }
+
+      resetFormDraft();
       await load();
-      setMessage("Form created successfully.");
+      setMessage(successMessage);
     } catch (err) {
       setMessage(err.message);
     }
@@ -407,6 +470,14 @@ function FormBuilderPage() {
     }
   };
 
+  const builderTitle = isEditing
+    ? "Update a reflective form"
+    : "Create a reflective form";
+  const builderSubtitle = isEditing
+    ? `Refresh the prompts${
+        editingForm ? ` for "${editingForm.title}"` : ""
+      } so your mentees continue to bloom.`
+    : "Craft prompts that resonate with the people you support";
   const sectionCardTitle = isAdmin ? "Form Management" : "Available forms";
   const sectionCardSubtitle = isAdmin
     ? "Steward templates, visibilities, and journaler links"
@@ -420,11 +491,19 @@ function FormBuilderPage() {
     <div className="flex w-full flex-1 flex-col gap-8">
       {message && <p className={infoTextClasses}>{message}</p>}
       {!isAdmin && (
-        <SectionCard
-          title="Create a reflective form"
-          subtitle="Craft prompts that resonate with the people you support"
-        >
-          <form className="space-y-6" onSubmit={handleCreateForm}>
+        <SectionCard title={builderTitle} subtitle={builderSubtitle}>
+          <form className="space-y-6" onSubmit={handleSubmitForm}>
+            {isEditing && (
+              <div className="space-y-2 rounded-2xl border border-dashed border-emerald-200 bg-white/60 p-5">
+                <p className="text-sm font-semibold text-emerald-900">
+                  Updating "{editingForm?.title || "your form"}"
+                </p>
+                <p className={`${mutedTextClasses} text-sm`}>
+                  Changes bloom immediately for every journaler linked to this
+                  form.
+                </p>
+              </div>
+            )}
             <label className="block text-sm font-semibold text-emerald-900/80">
               Title
               <input
@@ -546,9 +625,23 @@ function FormBuilderPage() {
               >
                 Add another field
               </button>
-              <button type="submit" className={`${primaryButtonClasses} w-full md:w-auto`}>
-                Save form
-              </button>
+              <div className="flex w-full flex-col gap-3 md:ml-auto md:w-auto md:flex-row">
+                {isEditing && (
+                  <button
+                    type="button"
+                    className={`${subtleButtonClasses} w-full px-5 py-2.5 text-sm md:w-auto`}
+                    onClick={handleCancelEdit}
+                  >
+                    Cancel editing
+                  </button>
+                )}
+                <button
+                  type="submit"
+                  className={`${primaryButtonClasses} w-full md:w-auto`}
+                >
+                  {isEditing ? "Update form" : "Save form"}
+                </button>
+              </div>
             </div>
           </form>
         </SectionCard>
@@ -676,6 +769,9 @@ function FormBuilderPage() {
               const mentees = Array.isArray(form.mentees)
                 ? form.mentees.filter((mentee) => mentee && mentee.id)
                 : [];
+              const canMentorManage =
+                isMentor && Number(form.created_by) === Number(user.id);
+              const canManageOwnForm = canMentorManage && !form.is_default;
 
               return (
                 <div
@@ -731,11 +827,36 @@ function FormBuilderPage() {
                           type="button"
                           className={`${dangerButtonClasses} w-full px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60 md:w-auto`}
                           disabled={form.is_default}
-                          onClick={() => handleDeleteForm(form.id)}
+                          onClick={() => handleDeleteForm(form)}
                         >
                           Delete form
                         </button>
                         {form.is_default && (
+                          <p className={`${mutedTextClasses} text-xs md:text-right`}>
+                            Default forms cannot be removed.
+                          </p>
+                        )}
+                      </>
+                    )}
+                    {canMentorManage && (
+                      <>
+                        <button
+                          type="button"
+                          className={`${secondaryButtonClasses} w-full px-4 py-2 text-sm md:w-auto`}
+                          onClick={() => beginEditingForm(form)}
+                          disabled={!canManageOwnForm}
+                        >
+                          Edit form
+                        </button>
+                        <button
+                          type="button"
+                          className={`${dangerButtonClasses} w-full px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-60 md:w-auto`}
+                          onClick={() => handleDeleteForm(form)}
+                          disabled={!canManageOwnForm}
+                        >
+                          Delete form
+                        </button>
+                        {!canManageOwnForm && (
                           <p className={`${mutedTextClasses} text-xs md:text-right`}>
                             Default forms cannot be removed.
                           </p>
@@ -756,7 +877,43 @@ function FormBuilderPage() {
 }
 
 function normalizeOptionList(options) {
-  return options.map((option) => option.trim()).filter(Boolean);
+  return options
+    .map((option) => {
+      if (typeof option === "string") {
+        return option.trim();
+      }
+
+      if (option && typeof option === "object") {
+        const value = option.value ?? option.label ?? "";
+        if (typeof value === "string") {
+          return value.trim();
+        }
+        return String(value ?? "").trim();
+      }
+
+      return String(option ?? "").trim();
+    })
+    .filter(Boolean);
+}
+
+function parseFieldOptions(value) {
+  if (Array.isArray(value)) {
+    return normalizeOptionList(value);
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return normalizeOptionList(parsed);
+      }
+    } catch (error) {
+      const segments = value.split(/[\n,]/);
+      return normalizeOptionList(segments);
+    }
+  }
+
+  return [];
 }
 
 function createField() {
@@ -767,6 +924,14 @@ function createField() {
     required: false,
     helperText: "",
     options: [],
+  };
+}
+
+function createEmptyDraft() {
+  return {
+    title: "",
+    description: "",
+    fields: [createField()],
   };
 }
 


### PR DESCRIPTION
## Summary
- preserve non-string select choices during mentor form updates by trimming with a nullish check
- document the mentor form update and deletion flows in the backend endpoint reference
- refresh the FormBuilder page docs to include the new PUT endpoint and updated unassign behaviour

## Testing
- npm run format:check
- npm run lint
- npm test
