### PR TITLE
Document password reset flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-10-16
+
+- Added `/api/auth/forgot-password` so visitors can request hashed, expiring reset links, wired the Aleya-branded email template, and documented the new env knobs for base URLs + TTL overrides across the backend knowledge base and AGENT notes.
+- Refreshed the frontend guides to cover the Forgot Password page and route so contributors know how the UI requests reset links without AuthContext wiring.
+
 ## 2025-10-15
 
 - Added a root `backend/index.js` shim so Docker and nodemon resolve the backend entrypoint consistently now that the actual server lives in `src/index.js`, and documented the expectation in `backend/AGENTS.md` for future updates.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -4,6 +4,7 @@
 - When changing backend routes or utilities, run `node --check <file>` on the touched modules to catch syntax issues early.
 - Keep mentor panic alert flows consistent with mentor escalation requirements and ensure new middleware is added as individual arguments instead of wrapped arrays when Express parsing causes issues.
 - Document all backend changes in `docs/Wiki.md` so future contributors understand the context behind updates.
+- Password reset requests now mint hashed tokens into `password_reset_tokens` and send Aleya-branded emails via `createPasswordResetEmail`; update the backend/frontend docs and env notes when adjusting this flow.
 - Mentor registrations no longer pass through a `mentor_approvals` table or admin review routes—please avoid reintroducing that flow. New mentors should remain immediately active after verification.
 - Transactional emails must be composed through `utils/emailTemplates.js` so the Aleya theme, preheader copy, and `[Aleya]` subject
   prefix stay consistent across messages. Extend that helper when introducing new mail types instead of crafting ad-hoc HTML.

--- a/backend/docs/schema.sql
+++ b/backend/docs/schema.sql
@@ -14,6 +14,13 @@ CREATE TABLE IF NOT EXISTS users (
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS mentor_profiles (
   user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
   expertise TEXT,
@@ -94,3 +101,5 @@ CREATE TABLE IF NOT EXISTS entry_comments (
 CREATE INDEX IF NOT EXISTS idx_journal_entries_user_date ON journal_entries (journaler_id, entry_date DESC);
 CREATE INDEX IF NOT EXISTS idx_mentor_assignments_journaler ON mentor_form_assignments (journaler_id);
 CREATE INDEX IF NOT EXISTS idx_mentor_links_journaler ON mentor_links (journaler_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON password_reset_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at ON password_reset_tokens (expires_at);

--- a/backend/src/utils/bootstrap.js
+++ b/backend/src/utils/bootstrap.js
@@ -17,6 +17,12 @@ const createTableStatements = [
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW()
     )`,
+  `CREATE TABLE IF NOT EXISTS password_reset_tokens (
+      user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      token_hash TEXT NOT NULL,
+      expires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
   `CREATE TABLE IF NOT EXISTS mentor_profiles (
       user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
       expertise TEXT,
@@ -89,6 +95,8 @@ const createTableStatements = [
   `CREATE INDEX IF NOT EXISTS idx_journal_entries_user_date ON journal_entries (journaler_id, entry_date DESC)`,
   `CREATE INDEX IF NOT EXISTS idx_mentor_assignments_journaler ON mentor_form_assignments (journaler_id)`,
   `CREATE INDEX IF NOT EXISTS idx_mentor_links_journaler ON mentor_links (journaler_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_password_reset_tokens_hash ON password_reset_tokens (token_hash)`,
+  `CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at ON password_reset_tokens (expires_at)`,
   `ALTER TABLE mentor_requests DROP CONSTRAINT IF EXISTS mentor_requests_status_check`,
   `ALTER TABLE mentor_requests ADD CONSTRAINT mentor_requests_status_check CHECK (status IN ('pending','mentor_accepted','confirmed','declined','ended'))`,
   `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_verified BOOLEAN DEFAULT FALSE`,

--- a/backend/src/utils/emailTemplates.js
+++ b/backend/src/utils/emailTemplates.js
@@ -526,11 +526,61 @@ function createVerificationEmail({ recipientName, verificationUrl, expiresText }
   };
 }
 
+function createPasswordResetEmail({ recipientName, resetUrl, expiresText }) {
+  const normalizedName =
+    typeof recipientName === "string" && recipientName.trim().length
+      ? recipientName.trim()
+      : "there";
+  const safeName = escapeHtml(normalizedName);
+  const safeExpires = escapeHtml(expiresText);
+  const safeUrl = escapeHtml(resetUrl);
+
+  const contentHtml = `
+    <p class="paragraph">Hi ${safeName},</p>
+    <p class="paragraph">
+      We received a request to reset your Aleya password. Follow the path below
+      to set a fresh password and return to your grove.
+    </p>
+    <div class="cta">
+      <a class="button" href="${resetUrl}">Reset password</a>
+    </div>
+    <p class="paragraph muted">
+      If the button above doesn't open, copy and paste this link into your
+      browser:
+      <span class="link-alt">${safeUrl}</span>
+    </p>
+    <p class="paragraph">
+      This link expires in ${safeExpires}. If you didn't request a reset, you
+      can safely ignore this email and your password will remain the same.
+    </p>
+  `;
+
+  const html = renderEmailLayout({
+    title: "Reset your Aleya password",
+    previewText: "Follow this link to refresh your Aleya password.",
+    contentHtml,
+  });
+
+  const text =
+    `Hi ${normalizedName},\n\n` +
+    "We received a request to reset your Aleya password. Use the link below to choose a new password:\n" +
+    `${resetUrl}\n\n` +
+    `This link expires in ${expiresText}. If you didn't request a reset, you can ignore this email and your password will remain the same.\n\n` +
+    "Rooted in care,\nThe Aleya team";
+
+  return {
+    subject: `${SUBJECT_PREFIX} Reset your Aleya password`,
+    text,
+    html,
+  };
+}
+
 module.exports = {
   SUBJECT_PREFIX,
   escapeHtml,
   renderEmailLayout,
   createVerificationEmail,
+  createPasswordResetEmail,
   createMentorEntryNotificationEmail,
   createMentorDigestEmail,
 };

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,11 @@
 # Backend Change Log
 
+## Password reset invitations (2025-09-30)
+- Added `POST /api/auth/forgot-password` to generate time-bound reset tokens, persist them in
+  `password_reset_tokens`, and email mentors or journalers a themed reset link via the mailer.
+- Bootstrapping now provisions the `password_reset_tokens` table and supporting indexes so
+  container starts automatically enforce expiry and lookup integrity.
+
 ## Container session resets (2025-09-24)
 - Each API process now issues a unique `X-Aleya-Boot-Id` header generated at startup. Clients use this identifier to detect
   container restarts and invalidate cached authentication state.

--- a/docs/backend/config.md
+++ b/docs/backend/config.md
@@ -19,6 +19,8 @@ An example environment file lives at `backend/.env.example`; copy it to `.env` a
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `SMTP_SECURE` – Required for Nodemailer transport validation at startup.
 - `EMAIL_VERIFICATION_URL` – Optional absolute URL for verification links; defaults to `APP_BASE_URL`/`FRONTEND_URL`/`CORS_ORIGIN` fallback.
 - `EMAIL_VERIFICATION_TTL_HOURS` – Overrides default 48h verification token lifetime.
+- `PASSWORD_RESET_URL` – Optional absolute URL for password reset links; falls back to `APP_BASE_URL`/`FRONTEND_URL`/`CORS_ORIGIN`.
+- `PASSWORD_RESET_TTL_HOURS` – Overrides the default 2h password reset token expiry window.
 - `MENTOR_DIGEST_WINDOW_HOURS` – Controls look-back window for the mentor digest job.
 
 ## Client Coordination

--- a/docs/backend/controllers.md
+++ b/docs/backend/controllers.md
@@ -3,7 +3,7 @@
 Aleya routes co-locate controller logic with Express routers. Key handlers include:
 
 ## AuthController (`backend/src/routes/auth.js`)
-- Validates registration/login payloads, hashes passwords, manages email verification tokens, and hydrates mentor profiles.
+- Validates registration/login payloads, hashes passwords, manages verification + password reset tokens, and hydrates mentor profiles.
 - Provides profile CRUD for authenticated users and admin mentor profile listings.
 
 ## FormsController (`backend/src/routes/forms.js`)

--- a/docs/backend/db.md
+++ b/docs/backend/db.md
@@ -7,7 +7,7 @@
 
 ## Schema
 - Canonical reference lives in `backend/docs/schema.sql` (see [Models](./models.md)).
-- Tables cover users, mentor profiles/requests/links, journal forms + fields, assignments, entries, and entry comments.
+- Tables cover users, password reset tokens, mentor profiles/requests/links, journal forms + fields, assignments, entries, and entry comments.
 
 ## Migrations & Seeding
 - No migration framework bundled; apply `schema.sql` manually or via external tools.

--- a/docs/backend/endpoints.md
+++ b/docs/backend/endpoints.md
@@ -10,6 +10,11 @@
 - **Request:** `{ email, password }`
 - **Response:** `200` with `{ token, user }` once verified. If unverified, resends verification token and returns `403`.
 
+### POST /api/auth/forgot-password
+- **Request:** `{ email }`
+- **Response:** `200` with success copy even when the account is missing; stores a hashed reset token with a rolling expiry and emails the Aleya-branded reset link when the user exists.
+- **Notes:** Token lifetime defaults to 2 hours but honours `PASSWORD_RESET_TTL_HOURS`; reset links use `PASSWORD_RESET_URL` or the configured app base URL fallbacks.
+
 ### POST /api/auth/verify-email
 - **Request:** `{ token }`
 - **Response:** `200` with success message; clears verification hash on success.

--- a/docs/backend/models.md
+++ b/docs/backend/models.md
@@ -6,6 +6,13 @@
 - `is_verified`, `verification_token_hash`, `verification_token_expires_at`
 - Timestamps: `created_at`, `updated_at`
 
+## password_reset_tokens
+- `user_id` (PK, FK → users, cascades on delete)
+- `token_hash`
+- `expires_at`
+- `created_at`
+- Indexes: unique hash (`idx_password_reset_tokens_hash`), expiry lookup (`idx_password_reset_tokens_expires_at`)
+
 ## mentor_profiles
 - `user_id` (PK, FK → users)
 - `expertise`, `availability`, `bio`

--- a/docs/backend/routes.md
+++ b/docs/backend/routes.md
@@ -1,7 +1,7 @@
 # Routes
 
 - **/api/auth** → `backend/src/routes/auth.js`
-  - Registration, login, email verification, profile CRUD, mentor expertise suggestions, admin mentor profile export.
+  - Registration, login, forgot-password token minting, email verification, profile CRUD, mentor expertise suggestions, admin mentor profile export.
 - **/api/forms** → `backend/src/routes/forms.js`
   - Fetch default/assigned forms, mentor form creation + assignment management, journaler/admin listing.
 - **/api/mentors** → `backend/src/routes/mentors.js`

--- a/docs/backend/services.md
+++ b/docs/backend/services.md
@@ -9,7 +9,7 @@
 
 ## utils/emailTemplates
 - **Location:** `backend/src/utils/emailTemplates.js`
-- **Role:** Centralises HTML/text templates for verification, mentor entry alerts, and digest emails to keep Aleya branding consistent.
+- **Role:** Centralises HTML/text templates for verification, password reset, mentor entry alerts, and digest emails to keep Aleya branding consistent.
 
 ## utils/mailer
 - **Location:** `backend/src/utils/mailer.js`

--- a/docs/frontend/context.md
+++ b/docs/frontend/context.md
@@ -6,3 +6,4 @@
 - **Persists:** Stores token + user in `localStorage` (`aleya.auth`) and restores on mount.
 - **Used by:** `AppRoutes` for guards, `Layout` for navigation, `PanicButton`, `SettingsPage`, dashboards, and mentorship flows.
 - **API touchpoints:** `/api/auth/login`, `/api/auth/register`, `/api/auth/me` (GET/PATCH/DELETE).
+- **Notes:** Password reset requests bypass the context; `ForgotPasswordPage` posts straight to `/api/auth/forgot-password` so logged-out visitors can trigger the email.

--- a/docs/frontend/pages.md
+++ b/docs/frontend/pages.md
@@ -10,6 +10,11 @@
 - **Components:** Styled form using Tailwind tokens; navigation copy plus CTA grid.
 - **APIs:** `authContext.login()` → `POST /api/auth/login`.
 
+## ForgotPasswordPage
+- **Route:** `/forgot-password`
+- **Components:** Single-field request form with Aleya copy, status banners, and CTA redirect back to login.
+- **APIs:** `apiClient.post("/auth/forgot-password")` submits the email directly without AuthContext involvement.
+
 ## RegisterPage
 - **Route:** `/register`
 - **Components:** Multi-step role selector, mentor expertise fields with `TagInput`, timezone select.

--- a/docs/frontend/routes.md
+++ b/docs/frontend/routes.md
@@ -2,6 +2,7 @@
 
 - `/` → `LandingPage` (public)
 - `/login` → `LoginPage` (public)
+- `/forgot-password` → `ForgotPasswordPage` (public)
 - `/register` → `RegisterPage` (public)
 - `/verify-email` → `VerifyEmailPage` (public token processing)
 - `/dashboard` → role router (`JournalerDashboard`, `MentorDashboard`, `AdminDashboard`) (protected)

--- a/docs/frontend/services.md
+++ b/docs/frontend/services.md
@@ -4,7 +4,7 @@
 - **Location:** `frontend/src/api/client.js`
 - **Exports:** `get`, `post`, `patch`, `del`, `request`.
 - **Behavior:** Prefixes requests with `process.env.REACT_APP_API_URL` (defaults to `http://localhost:5000/api`), attaches JSON headers, propagates bearer tokens, and normalises error payloads.
-- **Consumers:** `AuthContext`, dashboards, mentorship flows, forms builder, panic alerts.
+- **Consumers:** `AuthContext`, Forgot Password flow, dashboards, mentorship flows, forms builder, panic alerts.
 
 ## expertise utils
 - **Location:** `frontend/src/utils/expertise.js`


### PR DESCRIPTION
## Summary
- log the new /api/auth/forgot-password route, reset token storage, and env configuration in the backend guides and AGENT notes
- refresh the frontend documentation to describe the Forgot Password page, route, and apiClient usage
- record the password reset flow in the changelog so contributors see the new capability

## Testing
- npm run format:check
- npm run lint
- npm test
