### PR TITLE
feat: retune palette to heavenly blue

### DIFF
--- a/docs/theme.html
+++ b/docs/theme.html
@@ -19,11 +19,28 @@
     />
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
+      const heavenlyBluePalette = {
+        50: '#f1f7ff',
+        100: '#dcecff',
+        200: '#b7d8ff',
+        300: '#8fc1ff',
+        400: '#65a7ff',
+        500: '#3c8cff',
+        600: '#1f74e6',
+        700: '#1559bc',
+        800: '#124596',
+        900: '#0f3677',
+        950: '#081f4d',
+      };
+
       tailwind.config = {
         theme: {
           extend: {
             fontFamily: {
               sans: ['Poppins', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            },
+            colors: {
+              emerald: heavenlyBluePalette,
             },
           },
         },

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,18 @@
 /** @type {import('tailwindcss').Config} */
+const heavenlyBluePalette = {
+  50: "#f1f7ff",
+  100: "#dcecff",
+  200: "#b7d8ff",
+  300: "#8fc1ff",
+  400: "#65a7ff",
+  500: "#3c8cff",
+  600: "#1f74e6",
+  700: "#1559bc",
+  800: "#124596",
+  900: "#0f3677",
+  950: "#081f4d",
+};
+
 module.exports = {
   content: ["./public/index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
@@ -21,6 +35,9 @@ module.exports = {
           "Segoe UI",
           "sans-serif",
         ],
+      },
+      colors: {
+        emerald: heavenlyBluePalette,
       },
     },
   },


### PR DESCRIPTION
## Summary
- introduce a reusable Heavenly Blue palette for the Tailwind emerald token family
- reuse the same palette in the theme showcase so documented tokens match the application

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d253705db8833398a91fbff2382416